### PR TITLE
Make a start for parsing Markdown 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 examples/letters
 examples/numbers
 examples/csv-movies
+examples/markdown
 
 generated-docs/

--- a/examples/markdown.roc
+++ b/examples/markdown.roc
@@ -1,0 +1,44 @@
+app "example"
+    packages {
+        cli: "https://github.com/roc-lang/basic-cli/releases/download/0.8.1/x8URkvfyi9I0QhmVG98roKBUs_AZRkLFwFJVJ3942YA.tar.br",
+        parser: "../package/main.roc",
+    }
+    imports [
+        cli.Stdout,
+        parser.String.{ parseStr },
+        parser.Markdown.{ Markdown },
+    ]
+    provides [main] to cli
+
+content : Str
+content =
+    """
+    # Title
+
+    This is some text
+
+    [roc website](https://roc-lang.org)
+
+    ## Sub-title
+
+    ```roc
+    # some code
+    foo = bar
+    ```
+    """
+
+main =
+    parseStr Markdown.all content
+    |> Result.map \nodes -> renderContent "" nodes
+    |> Result.withDefault "PARSING ERROR"
+    |> Stdout.line
+
+renderContent : Str, List Markdown -> Str
+renderContent = \acc, nodes ->
+    when nodes is
+        [] -> acc
+        [Heading level str, .. as rest] -> Str.concat acc "HEADING: $(Inspect.toStr level) $(str)\n" |> renderContent rest
+        [Link { alt, href }, .. as rest] -> Str.concat acc "LINK: $(Inspect.toStr { alt, href })\n" |> renderContent rest
+        [Image { alt, href }, .. as rest] -> Str.concat acc "IMAGE: $(Inspect.toStr { alt, href })\n" |> renderContent rest
+        [Code { ext, pre }, .. as rest] -> Str.concat acc "CODE: $(Inspect.toStr { ext, pre })\n" |> renderContent rest
+        [TODO line, .. as rest] -> Str.concat acc "TODO: $(line)\n" |> renderContent rest

--- a/package/Markdown.roc
+++ b/package/Markdown.roc
@@ -1,5 +1,9 @@
 interface Markdown
     exposes [
+        Markdown,
+        heading,
+        link,
+        image,
     ]
     imports [
         Core.{ Parser, const, skip, keep, oneOf, chompWhile, map },
@@ -15,6 +19,9 @@ Markdown : [
 
     ## Link "roc" "https://roc-lang.org"
     Link Str Str,
+
+    ## Image "alt text" "/images/logo.png"
+    Image Str Str,
 
 ]
 
@@ -99,7 +106,7 @@ expect
 link : Parser Utf8 Markdown
 link =
     const (\label -> \href -> Link label href)
-    |> skip (codeunit '[')
+    |> skip (string "[")
     |> keep (chompWhile (\b -> b != ']') |> map strFromUtf8)
     |> skip (string "](")
     |> keep (chompWhile (\b -> b != ')') |> map strFromUtf8)
@@ -110,3 +117,24 @@ expect parseStr link "[roc](https://roc-lang.org)" == Ok (Link "roc" "https://ro
 expect
     a = parseStrPartial link "[roc](https://roc-lang.org)\nApples"
     a == Ok { val: Link "roc" "https://roc-lang.org", input: "\nApples" }
+
+## Images
+##
+## ```
+## expect parseStr image "![alt text](/images/logo.png)" == Ok (Image "alt text" "/images/logo.png")
+## ```
+image : Parser Utf8 Markdown
+image =
+    const (\alt -> \href -> Image alt href)
+    |> skip (string "![")
+    |> keep (chompWhile (\b -> b != ']') |> map strFromUtf8)
+    |> skip (string "](")
+    |> keep (chompWhile (\b -> b != ')') |> map strFromUtf8)
+    |> skip (codeunit ')')
+
+expect parseStr image "![alt text](/images/logo.png)" == Ok (Image "alt text" "/images/logo.png")
+
+expect
+    a = parseStrPartial image "![alt text](/images/logo.png)\nApples"
+    a == Ok { val: Image "alt text" "/images/logo.png", input: "\nApples" }
+

--- a/package/Markdown.roc
+++ b/package/Markdown.roc
@@ -1,0 +1,88 @@
+interface Markdown
+    exposes [
+    ]
+    imports [
+        Core.{ Parser, const, skip, keep, oneOf, chompWhile, map },
+        String.{ Utf8, parseStr, parseStrPartial, string, strFromUtf8 },
+    ]
+
+Level : [One, Two, Three, Four, Five, Six]
+
+## Content values
+Markdown : [
+    Heading Level Str,
+]
+
+endOfLine = oneOf [string "\n", string "\r\n"]
+notEndOfLine = \b -> b != '\n' && b != '\r'
+
+## Headings
+## [reference](https://www.markdownguide.org/basic-syntax/#headings)
+##
+## ```
+## expect parseStr heading "# Foo Bar" == Ok (Heading One "Foo Bar")
+## expect parseStr heading "Foo Bar\n---" == Ok (Heading Two "Foo Bar")
+## ```
+heading : Parser Utf8 Markdown
+heading =
+    oneOf [
+        inlineHeading,
+        twoLineHeadingLevelOne,
+        twoLineHeadingLevelTwo,
+    ]
+
+expect parseStr heading "# Foo Bar" == Ok (Heading One "Foo Bar")
+expect parseStr heading "Foo Bar\n---" == Ok (Heading Two "Foo Bar")
+
+inlineHeading =
+    const (\level -> \str -> Heading level str)
+    |> keep
+        (
+            oneOf [
+                const One |> skip (string "# "),
+                const Two |> skip (string "## "),
+                const Three |> skip (string "### "),
+                const Four |> skip (string "#### "),
+                const Five |> skip (string "##### "),
+                const Six |> skip (string "###### "),
+            ]
+        )
+    |> keep (chompWhile (notEndOfLine) |> map strFromUtf8)
+
+expect
+    a = parseStr inlineHeading "# Foo Bar"
+    a == Ok (Heading One "Foo Bar")
+
+expect
+    a = parseStrPartial inlineHeading "### Foo Bar\nBaz"
+    a == Ok { val: Heading Three "Foo Bar", input: "\nBaz" }
+
+twoLineHeadingLevelOne =
+    const (\str -> Heading One str)
+    |> keep (chompWhile (notEndOfLine) |> map strFromUtf8)
+    |> skip (endOfLine)
+    |> skip (string "==")
+    |> skip (chompWhile (\b -> notEndOfLine b && b == '='))
+
+expect
+    a = parseStr twoLineHeadingLevelOne "Foo Bar\n=="
+    a == Ok (Heading One "Foo Bar")
+
+expect
+    a = parseStrPartial twoLineHeadingLevelOne "Foo Bar\n=============\n"
+    a == Ok { val: Heading One "Foo Bar", input: "\n" }
+
+twoLineHeadingLevelTwo =
+    const (\str -> Heading Two str)
+    |> keep (chompWhile (notEndOfLine) |> map strFromUtf8)
+    |> skip (endOfLine)
+    |> skip (string "--")
+    |> skip (chompWhile (\b -> notEndOfLine b && b == '-'))
+
+expect
+    a = parseStr twoLineHeadingLevelTwo "Foo Bar\n---"
+    a == Ok (Heading Two "Foo Bar")
+
+expect
+    a = parseStrPartial twoLineHeadingLevelTwo "Foo Bar\n-----\nApples"
+    a == Ok { val: Heading Two "Foo Bar", input: "\nApples" }

--- a/package/main.roc
+++ b/package/main.roc
@@ -4,5 +4,6 @@ package "parser"
         String,
         CSV,
         HTTP,
+        Markdown,
     ]
     packages {}


### PR DESCRIPTION
This PR:
- adds a new example for CI
- adds `Markdown.roc` module for parsing markdown currently only supports (headings, links, images, and code blocks)

