### PR TITLE
remove unused rest var

### DIFF
--- a/package/String.roc
+++ b/package/String.roc
@@ -123,7 +123,7 @@ codeunit = \expectedCodeUnit ->
             [first, .. as rest] if first == expectedCodeUnit ->
                 Ok { val: expectedCodeUnit, input: rest }
 
-            [first, .. as rest] ->
+            [first, ..] ->
                 Err (ParsingFailure "expected char `$(strFromCodeunit expectedCodeUnit)` but found `$(strFromCodeunit first)`.\n While reading: `$(strFromUtf8 input)`")
 
 ## Parse an extact sequence of utf8


### PR DESCRIPTION
The latest roc version now produces a warning for this.

Can you do a new release after this? This warning causes problems for the examples CI.