### PR TITLE
Publish 0.11.0 docs and examples

### DIFF
--- a/.github/workflows/www.yaml
+++ b/.github/workflows/www.yaml
@@ -1,0 +1,41 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "www/**"
+      - ".github/workflows/www.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./www"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/examples/csv-movies.roc
+++ b/examples/csv-movies.roc
@@ -1,6 +1,6 @@
 app [main!] {
     cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-    parser: "../package/main.roc",
+    parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
 }
 
 import parser.Parser

--- a/examples/letters.roc
+++ b/examples/letters.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	parser: "../package/main.roc",
+	parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
 }
 
 import cli.Stdout

--- a/examples/markdown.roc
+++ b/examples/markdown.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	parser: "../package/main.roc",
+	parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
 }
 
 import cli.Stdout

--- a/examples/numbers.roc
+++ b/examples/numbers.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	parser: "../package/main.roc",
+	parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
 }
 
 import cli.Stdout

--- a/examples/xml-svg.roc
+++ b/examples/xml-svg.roc
@@ -2,7 +2,7 @@ app [main!] {
 	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
 	# TODO: point to the migrated html library
 	html: "https://github.com/lukewilliamboswell/roc-html/...",
-	parser: "../package/main.roc",
+	parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
 }
 
 import cli.Stdout

--- a/www/0.11.0/CSV/index.html
+++ b/www/0.11.0/CSV/index.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>CSV Docs</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+    <link rel="stylesheet" href="../styles.css">
+    <script src="../search.js" defer></script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <symbol id="link-icon" viewBox="0 0 640 512">
+      <path d="M562.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L405.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C189.5 251.2 196 330 246 380c56.5 56.5 148 56.5 204.5 0L562.8 267.7zM43.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C57 372 57 321 88.5 289.5L200.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C416.5 260.8 410 182 360 132c-56.5-56.5-148-56.5-204.5 0L43.2 244.3z"/>
+    </symbol>
+  </defs>
+</svg>
+    <nav id="sidebar-nav">
+        <div class="pkg-and-logo">
+            <a class="logo" href="../"><svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logo-link">
+    <title id="logo-link">Home</title>
+    <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
+</svg></a>
+            <h1 class="pkg-full-name"><a href="../">package</a></h1>
+        </div>
+        <div class="module-links-container">
+            <ul class="module-links">
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link active" data-module-name="CSV" href="../CSV/"><button class="entry-toggle"></button><span>CSV</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv">parse_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv_record">parse_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.record">record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.field">field</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.string">string</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.u64">u64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.f64">f64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv">parse_str_to_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv_record">parse_str_to_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.file">file</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVRecord">CSVRecord</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVField">CSVField</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="HTTP" href="../HTTP/"><button class="entry-toggle"></button><span>HTTP</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.request">request</a></li>
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.response">response</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Method">Method</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.HttpVersion">HttpVersion</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Header">Header</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Request">Request</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Response">Response</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Markdown" href="../Markdown/"><button class="entry-toggle"></button><span>Markdown</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.all">all</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.heading">heading</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.link">link</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.image">image</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.code">code</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Markdown/#Markdown.Level">Level</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Parser" href="../Parser/"><button class="entry-toggle"></button><span>Parser</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Parser/#Parser.build_primitive_parser">build_primitive_parser</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse_partial">parse_partial</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse">parse</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.fail">fail</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.const">const</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.alt">alt</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.apply">apply</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map">map</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map2">map2</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map3">map3</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.flatten">flatten</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.lazy">lazy</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.maybe">maybe</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.many">many</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_or_more">one_or_more</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.between">between</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by1">sep_by1</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by">sep_by</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.ignore">ignore</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.keep">keep</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.skip">skip</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_until">chomp_until</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_while">chomp_while</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Parser/#Parser.ParseResult">ParseResult</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="String" href="../String/"><button class="entry-toggle"></button><span>String</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../String/#String.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_str_partial">parse_str_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8">parse_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8_partial">parse_utf8_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit_satisfies">codeunit_satisfies</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit">codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.utf8">utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.string">string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_codeunit">any_codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_thing">any_thing</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_string">any_string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digit">digit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digits">digits</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_utf8">str_from_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_ascii">str_from_ascii</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../String/#String.Utf8">Utf8</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Xml" href="../Xml/"><button class="entry-toggle"></button><span>Xml</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Xml/#Xml.xml_parser">xml_parser</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Attribute">Attribute</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Declaration">Declaration</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Version">Version</a>
+                          <ul class="sidebar-sub-entries">
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.new">new</a></li>
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.is_eq">is_eq</a></li>
+                          </ul>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Encoding">Encoding</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Node">Node</a>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <main>
+        <form id="module-search-form">
+            <input type="search" id="module-search" placeholder="Search Documentation" autocomplete="off" />
+            <input type="search" id="module-search-nojs" placeholder="Enable JavaScript to search" autocomplete="off" disabled aria-label="Search requires JavaScript" />
+            <noscript><style>#module-search{display:none}#module-search-nojs{display:block}</style></noscript>
+            <button class="menu-toggle" type="button" aria-label="Toggle sidebar"><svg viewBox="0 6 18 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 6h18v2H0V6zm0 5h18v2H0v-2zm0 5h18v2H0v-2z"/>
+</svg></button>
+            <ul id="search-type-ahead" class="hidden">
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">SyntaxError</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSV</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv_record</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSVRecord</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">record</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.field"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">field</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.string"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.u64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">u64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.f64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">f64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">F64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSV</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv_record</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSVRecord</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.file"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">file</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">CSV</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVRecord"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVRecord</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">CSVField</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVField"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVField</span> <span class="type-ahead-signature">: <span class="type">Utf8</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">request</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Request</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">response</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Response</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Method"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Method</span> <span class="type-ahead-signature">: [<span class="type">Options</span>, <span class="type">Get</span>, <span class="type">Post</span>, <span class="type">Put</span>, <span class="type">Delete</span>, <span class="type">Head</span>, <span class="type">Trace</span>, <span class="type">Connect</span>, <span class="type">Patch</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.HttpVersion"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">HttpVersion</span> <span class="type-ahead-signature">: { major : <span class="type">U8</span>, minor : <span class="type">U8</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Header"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Header</span> <span class="type-ahead-signature">: [<span class="type">Header</span>(<span class="type">Str</span>, <span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Request</span> <span class="type-ahead-signature">: { method : <span class="type">Method</span>, uri : <span class="type">Str</span>, http_version : <span class="type">HttpVersion</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Response</span> <span class="type-ahead-signature">: { http_version : <span class="type">HttpVersion</span>, status_code : <span class="type">U16</span>, status : <span class="type">Str</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.all"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">all</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">Markdown</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.heading"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">heading</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.link"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">link</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.image"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">image</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.code"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">code</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.Level"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">Level</span> <span class="type-ahead-signature">: [<span class="type">One</span>, <span class="type">Two</span>, <span class="type">Three</span>, <span class="type">Four</span>, <span class="type">Five</span>, <span class="type">Six</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.build_primitive_parser"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">build_primitive_parser</span> <span class="type-ahead-signature">: (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse_partial"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span>, (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type-var">input</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.fail"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">fail</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, _)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.const"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">const</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.alt"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">alt</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.apply"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">apply</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_of"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map2"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map2</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map3"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map3</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>), (<span class="type-var">a</span>, <span class="type-var">b</span>, <span class="type-var">c</span><span class="sig-arrow"> -&gt; </span><span class="type-var">d</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">d</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.flatten"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">flatten</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, <span class="type">Str</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.lazy"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">lazy</span> <span class="type-ahead-signature">: ({  }<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.maybe"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">maybe</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">Nothing</span>]))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.many"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">many</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_or_more"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_or_more</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.between"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">between</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">open</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">close</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by1"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by1</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ignore"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ignore</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, {  })</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.keep"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">keep</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.skip"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">skip</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, _)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_until"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_until</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>)) <span class="kw">where</span> { <span class="type-var">a</span>.is_eq : <span class="type-var">a</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_while"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_while</span> <span class="type-ahead-signature">: (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ParseResult"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ParseResult</span> <span class="type-ahead-signature">: <span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type-var">input</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Str</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Utf8</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit_satisfies"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit_satisfies</span> <span class="type-ahead-signature">: (<span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">U8</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_codeunit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_thing"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_thing</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Utf8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digits"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digits</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.one_of"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_utf8</span> <span class="type-ahead-signature">: <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_ascii"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_ascii</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.Utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">Utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.xml_parser"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">xml_parser</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Xml</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Attribute"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Attribute</span> <span class="type-ahead-signature">: { name : <span class="type">Str</span>, value : <span class="type">Str</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Declaration"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Declaration</span> <span class="type-ahead-signature">: { version : <span class="type">Version</span>, encoding : [<span class="type">Given</span>(<span class="type">Encoding</span>), <span class="type">Missing</span>] }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Version</span> <span class="type-ahead-signature"></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.new"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">new</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Version</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.is_eq"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">is_eq</span> <span class="type-ahead-signature">: <span class="type">Version</span>, <span class="type">Version</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Encoding"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Encoding</span> <span class="type-ahead-signature">: [<span class="type">Utf8Encoding</span>, <span class="type">OtherEncoding</span>(<span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Node"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Node</span> <span class="type-ahead-signature">:= [<span class="type">Element</span>(<span class="type">Str</span>, <span class="type">List</span>({ name : <span class="type">Str</span>, value : <span class="type">Str</span> }), <span class="type">List</span>(<span class="type">Node</span>)), <span class="type">Text</span>(<span class="type">Str</span>)]</span></a></li>
+            </ul>
+        </form>
+        <div class="main-content">
+        <h1 class="module-name">CSV</h1>
+        <article class="entry entry-value" id="CSV.parse_str">
+            <div class="entry-signature">
+                <a href="#CSV.parse_str" class="entry-anchor" aria-label="Permalink to parse_str"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.parse_str" class="entry-name-link"><strong>parse_str</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">SyntaxError</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.parse_csv">
+            <div class="entry-signature">
+                <a href="#CSV.parse_csv" class="entry-anchor" aria-label="Permalink to parse_csv"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.parse_csv" class="entry-name-link"><strong>parse_csv</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSV</span><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.parse_csv_record">
+            <div class="entry-signature">
+                <a href="#CSV.parse_csv_record" class="entry-anchor" aria-label="Permalink to parse_csv_record"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.parse_csv_record" class="entry-name-link"><strong>parse_csv_record</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSVRecord</span><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.record">
+            <div class="entry-signature">
+                <a href="#CSV.record" class="entry-anchor" aria-label="Permalink to record"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.record" class="entry-name-link"><strong>record</strong></a> : <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.field">
+            <div class="entry-signature">
+                <a href="#CSV.field" class="entry-anchor" aria-label="Permalink to field"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.field" class="entry-name-link"><strong>field</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.string">
+            <div class="entry-signature">
+                <a href="#CSV.string" class="entry-anchor" aria-label="Permalink to string"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.string" class="entry-name-link"><strong>string</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">CSVField</span>, <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.u64">
+            <div class="entry-signature">
+                <a href="#CSV.u64" class="entry-anchor" aria-label="Permalink to u64"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.u64" class="entry-name-link"><strong>u64</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">CSVField</span>, <a href="https://roc-lang.org/builtins/main/Num#U64"><span class="type">U64</span></a>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.f64">
+            <div class="entry-signature">
+                <a href="#CSV.f64" class="entry-anchor" aria-label="Permalink to f64"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.f64" class="entry-name-link"><strong>f64</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">CSVField</span>, <a href="https://roc-lang.org/builtins/main/Num#F64"><span class="type">F64</span></a>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.parse_str_to_csv">
+            <div class="entry-signature">
+                <a href="#CSV.parse_str_to_csv" class="entry-anchor" aria-label="Permalink to parse_str_to_csv"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.parse_str_to_csv" class="entry-name-link"><strong>parse_str_to_csv</strong></a> : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<span class="type">CSV</span>, [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">ParsingIncomplete</span>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>)])</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.parse_str_to_csv_record">
+            <div class="entry-signature">
+                <a href="#CSV.parse_str_to_csv_record" class="entry-anchor" aria-label="Permalink to parse_str_to_csv_record"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.parse_str_to_csv_record" class="entry-name-link"><strong>parse_str_to_csv_record</strong></a> : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<span class="type">CSVRecord</span>, [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">ParsingIncomplete</span>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>)])</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="CSV.file">
+            <div class="entry-signature">
+                <a href="#CSV.file" class="entry-anchor" aria-label="Permalink to file"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.file" class="entry-name-link"><strong>file</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <span class="type">CSV</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="CSV.CSVRecord">
+            <div class="entry-signature">
+                <a href="#CSV.CSVRecord" class="entry-anchor" aria-label="Permalink to CSVRecord"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.CSVRecord" class="entry-name-link"><strong>CSVRecord</strong></a> : <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type">CSVField</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="CSV.CSVField">
+            <div class="entry-signature">
+                <a href="#CSV.CSVField" class="entry-anchor" aria-label="Permalink to CSVField"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#CSV.CSVField" class="entry-name-link"><strong>CSVField</strong></a> : <a href="../String/#String.Utf8"><span class="type">Utf8</span></a></code>
+            </div>
+        </article>
+        </div>
+        <footer><p>Made by people who like to make nice things.</p></footer>
+    </main>
+</body>
+</html>

--- a/www/0.11.0/HTTP/index.html
+++ b/www/0.11.0/HTTP/index.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>HTTP Docs</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+    <link rel="stylesheet" href="../styles.css">
+    <script src="../search.js" defer></script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <symbol id="link-icon" viewBox="0 0 640 512">
+      <path d="M562.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L405.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C189.5 251.2 196 330 246 380c56.5 56.5 148 56.5 204.5 0L562.8 267.7zM43.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C57 372 57 321 88.5 289.5L200.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C416.5 260.8 410 182 360 132c-56.5-56.5-148-56.5-204.5 0L43.2 244.3z"/>
+    </symbol>
+  </defs>
+</svg>
+    <nav id="sidebar-nav">
+        <div class="pkg-and-logo">
+            <a class="logo" href="../"><svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logo-link">
+    <title id="logo-link">Home</title>
+    <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
+</svg></a>
+            <h1 class="pkg-full-name"><a href="../">package</a></h1>
+        </div>
+        <div class="module-links-container">
+            <ul class="module-links">
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="CSV" href="../CSV/"><button class="entry-toggle"></button><span>CSV</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv">parse_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv_record">parse_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.record">record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.field">field</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.string">string</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.u64">u64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.f64">f64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv">parse_str_to_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv_record">parse_str_to_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.file">file</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVRecord">CSVRecord</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVField">CSVField</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link active" data-module-name="HTTP" href="../HTTP/"><button class="entry-toggle"></button><span>HTTP</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.request">request</a></li>
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.response">response</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Method">Method</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.HttpVersion">HttpVersion</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Header">Header</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Request">Request</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Response">Response</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Markdown" href="../Markdown/"><button class="entry-toggle"></button><span>Markdown</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.all">all</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.heading">heading</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.link">link</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.image">image</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.code">code</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Markdown/#Markdown.Level">Level</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Parser" href="../Parser/"><button class="entry-toggle"></button><span>Parser</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Parser/#Parser.build_primitive_parser">build_primitive_parser</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse_partial">parse_partial</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse">parse</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.fail">fail</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.const">const</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.alt">alt</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.apply">apply</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map">map</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map2">map2</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map3">map3</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.flatten">flatten</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.lazy">lazy</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.maybe">maybe</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.many">many</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_or_more">one_or_more</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.between">between</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by1">sep_by1</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by">sep_by</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.ignore">ignore</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.keep">keep</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.skip">skip</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_until">chomp_until</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_while">chomp_while</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Parser/#Parser.ParseResult">ParseResult</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="String" href="../String/"><button class="entry-toggle"></button><span>String</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../String/#String.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_str_partial">parse_str_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8">parse_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8_partial">parse_utf8_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit_satisfies">codeunit_satisfies</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit">codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.utf8">utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.string">string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_codeunit">any_codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_thing">any_thing</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_string">any_string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digit">digit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digits">digits</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_utf8">str_from_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_ascii">str_from_ascii</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../String/#String.Utf8">Utf8</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Xml" href="../Xml/"><button class="entry-toggle"></button><span>Xml</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Xml/#Xml.xml_parser">xml_parser</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Attribute">Attribute</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Declaration">Declaration</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Version">Version</a>
+                          <ul class="sidebar-sub-entries">
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.new">new</a></li>
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.is_eq">is_eq</a></li>
+                          </ul>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Encoding">Encoding</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Node">Node</a>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <main>
+        <form id="module-search-form">
+            <input type="search" id="module-search" placeholder="Search Documentation" autocomplete="off" />
+            <input type="search" id="module-search-nojs" placeholder="Enable JavaScript to search" autocomplete="off" disabled aria-label="Search requires JavaScript" />
+            <noscript><style>#module-search{display:none}#module-search-nojs{display:block}</style></noscript>
+            <button class="menu-toggle" type="button" aria-label="Toggle sidebar"><svg viewBox="0 6 18 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 6h18v2H0V6zm0 5h18v2H0v-2zm0 5h18v2H0v-2z"/>
+</svg></button>
+            <ul id="search-type-ahead" class="hidden">
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">SyntaxError</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSV</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv_record</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSVRecord</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">record</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.field"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">field</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.string"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.u64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">u64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.f64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">f64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">F64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSV</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv_record</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSVRecord</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.file"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">file</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">CSV</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVRecord"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVRecord</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">CSVField</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVField"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVField</span> <span class="type-ahead-signature">: <span class="type">Utf8</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">request</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Request</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">response</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Response</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Method"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Method</span> <span class="type-ahead-signature">: [<span class="type">Options</span>, <span class="type">Get</span>, <span class="type">Post</span>, <span class="type">Put</span>, <span class="type">Delete</span>, <span class="type">Head</span>, <span class="type">Trace</span>, <span class="type">Connect</span>, <span class="type">Patch</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.HttpVersion"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">HttpVersion</span> <span class="type-ahead-signature">: { major : <span class="type">U8</span>, minor : <span class="type">U8</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Header"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Header</span> <span class="type-ahead-signature">: [<span class="type">Header</span>(<span class="type">Str</span>, <span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Request</span> <span class="type-ahead-signature">: { method : <span class="type">Method</span>, uri : <span class="type">Str</span>, http_version : <span class="type">HttpVersion</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Response</span> <span class="type-ahead-signature">: { http_version : <span class="type">HttpVersion</span>, status_code : <span class="type">U16</span>, status : <span class="type">Str</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.all"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">all</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">Markdown</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.heading"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">heading</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.link"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">link</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.image"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">image</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.code"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">code</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.Level"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">Level</span> <span class="type-ahead-signature">: [<span class="type">One</span>, <span class="type">Two</span>, <span class="type">Three</span>, <span class="type">Four</span>, <span class="type">Five</span>, <span class="type">Six</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.build_primitive_parser"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">build_primitive_parser</span> <span class="type-ahead-signature">: (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse_partial"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span>, (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type-var">input</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.fail"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">fail</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, _)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.const"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">const</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.alt"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">alt</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.apply"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">apply</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_of"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map2"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map2</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map3"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map3</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>), (<span class="type-var">a</span>, <span class="type-var">b</span>, <span class="type-var">c</span><span class="sig-arrow"> -&gt; </span><span class="type-var">d</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">d</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.flatten"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">flatten</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, <span class="type">Str</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.lazy"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">lazy</span> <span class="type-ahead-signature">: ({  }<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.maybe"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">maybe</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">Nothing</span>]))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.many"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">many</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_or_more"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_or_more</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.between"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">between</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">open</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">close</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by1"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by1</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ignore"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ignore</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, {  })</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.keep"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">keep</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.skip"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">skip</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, _)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_until"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_until</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>)) <span class="kw">where</span> { <span class="type-var">a</span>.is_eq : <span class="type-var">a</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_while"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_while</span> <span class="type-ahead-signature">: (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ParseResult"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ParseResult</span> <span class="type-ahead-signature">: <span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type-var">input</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Str</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Utf8</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit_satisfies"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit_satisfies</span> <span class="type-ahead-signature">: (<span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">U8</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_codeunit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_thing"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_thing</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Utf8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digits"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digits</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.one_of"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_utf8</span> <span class="type-ahead-signature">: <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_ascii"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_ascii</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.Utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">Utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.xml_parser"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">xml_parser</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Xml</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Attribute"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Attribute</span> <span class="type-ahead-signature">: { name : <span class="type">Str</span>, value : <span class="type">Str</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Declaration"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Declaration</span> <span class="type-ahead-signature">: { version : <span class="type">Version</span>, encoding : [<span class="type">Given</span>(<span class="type">Encoding</span>), <span class="type">Missing</span>] }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Version</span> <span class="type-ahead-signature"></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.new"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">new</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Version</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.is_eq"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">is_eq</span> <span class="type-ahead-signature">: <span class="type">Version</span>, <span class="type">Version</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Encoding"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Encoding</span> <span class="type-ahead-signature">: [<span class="type">Utf8Encoding</span>, <span class="type">OtherEncoding</span>(<span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Node"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Node</span> <span class="type-ahead-signature">:= [<span class="type">Element</span>(<span class="type">Str</span>, <span class="type">List</span>({ name : <span class="type">Str</span>, value : <span class="type">Str</span> }), <span class="type">List</span>(<span class="type">Node</span>)), <span class="type">Text</span>(<span class="type">Str</span>)]</span></a></li>
+            </ul>
+        </form>
+        <div class="main-content">
+        <h1 class="module-name">HTTP</h1>
+        <article class="entry entry-value" id="HTTP.request">
+            <div class="entry-signature">
+                <a href="#HTTP.request" class="entry-anchor" aria-label="Permalink to request"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#HTTP.request" class="entry-name-link"><strong>request</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <span class="type">Request</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="HTTP.response">
+            <div class="entry-signature">
+                <a href="#HTTP.response" class="entry-anchor" aria-label="Permalink to response"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#HTTP.response" class="entry-name-link"><strong>response</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <span class="type">Response</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="HTTP.Method">
+            <div class="entry-signature">
+                <a href="#HTTP.Method" class="entry-anchor" aria-label="Permalink to Method"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#HTTP.Method" class="entry-name-link"><strong>Method</strong></a> : [<span class="type">Options</span>, <span class="type">Get</span>, <span class="type">Post</span>, <span class="type">Put</span>, <span class="type">Delete</span>, <span class="type">Head</span>, <span class="type">Trace</span>, <span class="type">Connect</span>, <span class="type">Patch</span>]</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="HTTP.HttpVersion">
+            <div class="entry-signature">
+                <a href="#HTTP.HttpVersion" class="entry-anchor" aria-label="Permalink to HttpVersion"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#HTTP.HttpVersion" class="entry-name-link"><strong>HttpVersion</strong></a> : { major : <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>, minor : <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a> }</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="HTTP.Header">
+            <div class="entry-signature">
+                <a href="#HTTP.Header" class="entry-anchor" aria-label="Permalink to Header"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#HTTP.Header" class="entry-name-link"><strong>Header</strong></a> : [<span class="type">Header</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>, <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)]</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="HTTP.Request">
+            <div class="entry-signature">
+                <a href="#HTTP.Request" class="entry-anchor" aria-label="Permalink to Request"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#HTTP.Request" class="entry-name-link"><strong>Request</strong></a> : { method : <span class="type">Method</span>, uri : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>, http_version : <span class="type">HttpVersion</span>, headers : <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type">Header</span>), body : <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>) }</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="HTTP.Response">
+            <div class="entry-signature">
+                <a href="#HTTP.Response" class="entry-anchor" aria-label="Permalink to Response"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#HTTP.Response" class="entry-name-link"><strong>Response</strong></a> : { http_version : <span class="type">HttpVersion</span>, status_code : <a href="https://roc-lang.org/builtins/main/Num#U16"><span class="type">U16</span></a>, status : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>, headers : <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type">Header</span>), body : <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>) }</code>
+            </div>
+        </article>
+        </div>
+        <footer><p>Made by people who like to make nice things.</p></footer>
+    </main>
+</body>
+</html>

--- a/www/0.11.0/Markdown/index.html
+++ b/www/0.11.0/Markdown/index.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Markdown Docs</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+    <link rel="stylesheet" href="../styles.css">
+    <script src="../search.js" defer></script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <symbol id="link-icon" viewBox="0 0 640 512">
+      <path d="M562.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L405.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C189.5 251.2 196 330 246 380c56.5 56.5 148 56.5 204.5 0L562.8 267.7zM43.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C57 372 57 321 88.5 289.5L200.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C416.5 260.8 410 182 360 132c-56.5-56.5-148-56.5-204.5 0L43.2 244.3z"/>
+    </symbol>
+  </defs>
+</svg>
+    <nav id="sidebar-nav">
+        <div class="pkg-and-logo">
+            <a class="logo" href="../"><svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logo-link">
+    <title id="logo-link">Home</title>
+    <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
+</svg></a>
+            <h1 class="pkg-full-name"><a href="../">package</a></h1>
+        </div>
+        <div class="module-links-container">
+            <ul class="module-links">
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="CSV" href="../CSV/"><button class="entry-toggle"></button><span>CSV</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv">parse_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv_record">parse_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.record">record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.field">field</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.string">string</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.u64">u64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.f64">f64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv">parse_str_to_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv_record">parse_str_to_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.file">file</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVRecord">CSVRecord</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVField">CSVField</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="HTTP" href="../HTTP/"><button class="entry-toggle"></button><span>HTTP</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.request">request</a></li>
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.response">response</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Method">Method</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.HttpVersion">HttpVersion</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Header">Header</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Request">Request</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Response">Response</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link active" data-module-name="Markdown" href="../Markdown/"><button class="entry-toggle"></button><span>Markdown</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.all">all</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.heading">heading</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.link">link</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.image">image</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.code">code</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Markdown/#Markdown.Level">Level</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Parser" href="../Parser/"><button class="entry-toggle"></button><span>Parser</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Parser/#Parser.build_primitive_parser">build_primitive_parser</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse_partial">parse_partial</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse">parse</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.fail">fail</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.const">const</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.alt">alt</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.apply">apply</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map">map</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map2">map2</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map3">map3</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.flatten">flatten</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.lazy">lazy</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.maybe">maybe</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.many">many</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_or_more">one_or_more</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.between">between</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by1">sep_by1</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by">sep_by</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.ignore">ignore</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.keep">keep</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.skip">skip</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_until">chomp_until</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_while">chomp_while</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Parser/#Parser.ParseResult">ParseResult</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="String" href="../String/"><button class="entry-toggle"></button><span>String</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../String/#String.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_str_partial">parse_str_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8">parse_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8_partial">parse_utf8_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit_satisfies">codeunit_satisfies</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit">codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.utf8">utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.string">string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_codeunit">any_codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_thing">any_thing</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_string">any_string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digit">digit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digits">digits</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_utf8">str_from_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_ascii">str_from_ascii</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../String/#String.Utf8">Utf8</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Xml" href="../Xml/"><button class="entry-toggle"></button><span>Xml</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Xml/#Xml.xml_parser">xml_parser</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Attribute">Attribute</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Declaration">Declaration</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Version">Version</a>
+                          <ul class="sidebar-sub-entries">
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.new">new</a></li>
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.is_eq">is_eq</a></li>
+                          </ul>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Encoding">Encoding</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Node">Node</a>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <main>
+        <form id="module-search-form">
+            <input type="search" id="module-search" placeholder="Search Documentation" autocomplete="off" />
+            <input type="search" id="module-search-nojs" placeholder="Enable JavaScript to search" autocomplete="off" disabled aria-label="Search requires JavaScript" />
+            <noscript><style>#module-search{display:none}#module-search-nojs{display:block}</style></noscript>
+            <button class="menu-toggle" type="button" aria-label="Toggle sidebar"><svg viewBox="0 6 18 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 6h18v2H0V6zm0 5h18v2H0v-2zm0 5h18v2H0v-2z"/>
+</svg></button>
+            <ul id="search-type-ahead" class="hidden">
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">SyntaxError</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSV</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv_record</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSVRecord</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">record</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.field"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">field</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.string"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.u64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">u64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.f64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">f64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">F64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSV</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv_record</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSVRecord</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.file"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">file</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">CSV</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVRecord"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVRecord</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">CSVField</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVField"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVField</span> <span class="type-ahead-signature">: <span class="type">Utf8</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">request</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Request</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">response</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Response</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Method"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Method</span> <span class="type-ahead-signature">: [<span class="type">Options</span>, <span class="type">Get</span>, <span class="type">Post</span>, <span class="type">Put</span>, <span class="type">Delete</span>, <span class="type">Head</span>, <span class="type">Trace</span>, <span class="type">Connect</span>, <span class="type">Patch</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.HttpVersion"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">HttpVersion</span> <span class="type-ahead-signature">: { major : <span class="type">U8</span>, minor : <span class="type">U8</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Header"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Header</span> <span class="type-ahead-signature">: [<span class="type">Header</span>(<span class="type">Str</span>, <span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Request</span> <span class="type-ahead-signature">: { method : <span class="type">Method</span>, uri : <span class="type">Str</span>, http_version : <span class="type">HttpVersion</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Response</span> <span class="type-ahead-signature">: { http_version : <span class="type">HttpVersion</span>, status_code : <span class="type">U16</span>, status : <span class="type">Str</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.all"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">all</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">Markdown</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.heading"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">heading</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.link"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">link</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.image"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">image</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.code"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">code</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.Level"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">Level</span> <span class="type-ahead-signature">: [<span class="type">One</span>, <span class="type">Two</span>, <span class="type">Three</span>, <span class="type">Four</span>, <span class="type">Five</span>, <span class="type">Six</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.build_primitive_parser"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">build_primitive_parser</span> <span class="type-ahead-signature">: (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse_partial"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span>, (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type-var">input</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.fail"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">fail</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, _)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.const"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">const</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.alt"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">alt</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.apply"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">apply</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_of"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map2"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map2</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map3"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map3</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>), (<span class="type-var">a</span>, <span class="type-var">b</span>, <span class="type-var">c</span><span class="sig-arrow"> -&gt; </span><span class="type-var">d</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">d</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.flatten"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">flatten</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, <span class="type">Str</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.lazy"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">lazy</span> <span class="type-ahead-signature">: ({  }<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.maybe"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">maybe</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">Nothing</span>]))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.many"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">many</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_or_more"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_or_more</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.between"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">between</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">open</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">close</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by1"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by1</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ignore"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ignore</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, {  })</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.keep"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">keep</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.skip"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">skip</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, _)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_until"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_until</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>)) <span class="kw">where</span> { <span class="type-var">a</span>.is_eq : <span class="type-var">a</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_while"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_while</span> <span class="type-ahead-signature">: (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ParseResult"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ParseResult</span> <span class="type-ahead-signature">: <span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type-var">input</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Str</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Utf8</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit_satisfies"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit_satisfies</span> <span class="type-ahead-signature">: (<span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">U8</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_codeunit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_thing"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_thing</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Utf8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digits"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digits</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.one_of"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_utf8</span> <span class="type-ahead-signature">: <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_ascii"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_ascii</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.Utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">Utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.xml_parser"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">xml_parser</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Xml</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Attribute"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Attribute</span> <span class="type-ahead-signature">: { name : <span class="type">Str</span>, value : <span class="type">Str</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Declaration"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Declaration</span> <span class="type-ahead-signature">: { version : <span class="type">Version</span>, encoding : [<span class="type">Given</span>(<span class="type">Encoding</span>), <span class="type">Missing</span>] }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Version</span> <span class="type-ahead-signature"></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.new"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">new</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Version</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.is_eq"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">is_eq</span> <span class="type-ahead-signature">: <span class="type">Version</span>, <span class="type">Version</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Encoding"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Encoding</span> <span class="type-ahead-signature">: [<span class="type">Utf8Encoding</span>, <span class="type">OtherEncoding</span>(<span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Node"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Node</span> <span class="type-ahead-signature">:= [<span class="type">Element</span>(<span class="type">Str</span>, <span class="type">List</span>({ name : <span class="type">Str</span>, value : <span class="type">Str</span> }), <span class="type">List</span>(<span class="type">Node</span>)), <span class="type">Text</span>(<span class="type">Str</span>)]</span></a></li>
+            </ul>
+        </form>
+        <div class="main-content">
+        <h1 class="module-name">Markdown</h1>
+        <code class="entry-type-def">:= [<span class="type">Heading</span>(<span class="type">Level</span>, <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">Link</span>({ alt : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>, href : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a> }), <span class="type">Image</span>({ alt : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>, href : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a> }), <span class="type">Code</span>({ ext : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>, pre : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a> }), <span class="type">TODO</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)]</code>
+        <article class="entry entry-value" id="Markdown.all">
+            <div class="entry-signature">
+                <a href="#Markdown.all" class="entry-anchor" aria-label="Permalink to all"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Markdown.all" class="entry-name-link"><strong>all</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type">Markdown</span>))</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Markdown.heading">
+            <div class="entry-signature">
+                <a href="#Markdown.heading" class="entry-anchor" aria-label="Permalink to heading"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Markdown.heading" class="entry-name-link"><strong>heading</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <span class="type">Markdown</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Headings</p>
+                <pre><code>expect String.parse_str(heading, &quot;# Foo Bar&quot;) == Ok(Heading(One, &quot;Foo Bar&quot;))
+expect String.parse_str(heading, &quot;Foo Bar\n---&quot;) == Ok(Heading(Two, &quot;Foo Bar&quot;))</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Markdown.link">
+            <div class="entry-signature">
+                <a href="#Markdown.link" class="entry-anchor" aria-label="Permalink to link"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Markdown.link" class="entry-name-link"><strong>link</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <span class="type">Markdown</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Links</p>
+                <pre><code>expect String.parse_str(link, &quot;[roc](https://roc-lang.org)&quot;) == Ok(Link(&quot;roc&quot;, &quot;https://roc-lang.org&quot;))</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Markdown.image">
+            <div class="entry-signature">
+                <a href="#Markdown.image" class="entry-anchor" aria-label="Permalink to image"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Markdown.image" class="entry-name-link"><strong>image</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <span class="type">Markdown</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Images</p>
+                <pre><code>expect String.parse_str(image, &quot;![alt text](/images/logo.png)&quot;) == Ok(Image(&quot;alt text&quot;, &quot;/images/logo.png&quot;))</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Markdown.code">
+            <div class="entry-signature">
+                <a href="#Markdown.code" class="entry-anchor" aria-label="Permalink to code"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Markdown.code" class="entry-name-link"><strong>code</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <span class="type">Markdown</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Parse code blocks using triple backticks
+supports block extension e.g. <code></code>`roc</p>
+                <pre><code>expect {
+    text =
+        \\```roc
+        \\# some code
+        \\foo = bar
+        \\```
+
+    a = String.parse_str(code, text)
+    a == Ok(Code({ ext: &quot;roc&quot;, pre: &quot;# some code\nfoo = bar\n&quot; }))
+}</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Markdown.Level">
+            <div class="entry-signature">
+                <a href="#Markdown.Level" class="entry-anchor" aria-label="Permalink to Level"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Markdown.Level" class="entry-name-link"><strong>Level</strong></a> : [<span class="type">One</span>, <span class="type">Two</span>, <span class="type">Three</span>, <span class="type">Four</span>, <span class="type">Five</span>, <span class="type">Six</span>]</code>
+            </div>
+        </article>
+        </div>
+        <footer><p>Made by people who like to make nice things.</p></footer>
+    </main>
+</body>
+</html>

--- a/www/0.11.0/Parser/index.html
+++ b/www/0.11.0/Parser/index.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Parser Docs</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+    <link rel="stylesheet" href="../styles.css">
+    <script src="../search.js" defer></script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <symbol id="link-icon" viewBox="0 0 640 512">
+      <path d="M562.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L405.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C189.5 251.2 196 330 246 380c56.5 56.5 148 56.5 204.5 0L562.8 267.7zM43.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C57 372 57 321 88.5 289.5L200.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C416.5 260.8 410 182 360 132c-56.5-56.5-148-56.5-204.5 0L43.2 244.3z"/>
+    </symbol>
+  </defs>
+</svg>
+    <nav id="sidebar-nav">
+        <div class="pkg-and-logo">
+            <a class="logo" href="../"><svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logo-link">
+    <title id="logo-link">Home</title>
+    <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
+</svg></a>
+            <h1 class="pkg-full-name"><a href="../">package</a></h1>
+        </div>
+        <div class="module-links-container">
+            <ul class="module-links">
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="CSV" href="../CSV/"><button class="entry-toggle"></button><span>CSV</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv">parse_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv_record">parse_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.record">record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.field">field</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.string">string</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.u64">u64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.f64">f64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv">parse_str_to_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv_record">parse_str_to_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.file">file</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVRecord">CSVRecord</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVField">CSVField</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="HTTP" href="../HTTP/"><button class="entry-toggle"></button><span>HTTP</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.request">request</a></li>
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.response">response</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Method">Method</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.HttpVersion">HttpVersion</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Header">Header</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Request">Request</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Response">Response</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Markdown" href="../Markdown/"><button class="entry-toggle"></button><span>Markdown</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.all">all</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.heading">heading</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.link">link</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.image">image</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.code">code</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Markdown/#Markdown.Level">Level</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link active" data-module-name="Parser" href="../Parser/"><button class="entry-toggle"></button><span>Parser</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Parser/#Parser.build_primitive_parser">build_primitive_parser</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse_partial">parse_partial</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse">parse</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.fail">fail</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.const">const</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.alt">alt</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.apply">apply</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map">map</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map2">map2</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map3">map3</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.flatten">flatten</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.lazy">lazy</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.maybe">maybe</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.many">many</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_or_more">one_or_more</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.between">between</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by1">sep_by1</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by">sep_by</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.ignore">ignore</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.keep">keep</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.skip">skip</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_until">chomp_until</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_while">chomp_while</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Parser/#Parser.ParseResult">ParseResult</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="String" href="../String/"><button class="entry-toggle"></button><span>String</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../String/#String.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_str_partial">parse_str_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8">parse_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8_partial">parse_utf8_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit_satisfies">codeunit_satisfies</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit">codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.utf8">utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.string">string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_codeunit">any_codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_thing">any_thing</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_string">any_string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digit">digit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digits">digits</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_utf8">str_from_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_ascii">str_from_ascii</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../String/#String.Utf8">Utf8</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Xml" href="../Xml/"><button class="entry-toggle"></button><span>Xml</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Xml/#Xml.xml_parser">xml_parser</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Attribute">Attribute</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Declaration">Declaration</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Version">Version</a>
+                          <ul class="sidebar-sub-entries">
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.new">new</a></li>
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.is_eq">is_eq</a></li>
+                          </ul>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Encoding">Encoding</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Node">Node</a>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <main>
+        <form id="module-search-form">
+            <input type="search" id="module-search" placeholder="Search Documentation" autocomplete="off" />
+            <input type="search" id="module-search-nojs" placeholder="Enable JavaScript to search" autocomplete="off" disabled aria-label="Search requires JavaScript" />
+            <noscript><style>#module-search{display:none}#module-search-nojs{display:block}</style></noscript>
+            <button class="menu-toggle" type="button" aria-label="Toggle sidebar"><svg viewBox="0 6 18 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 6h18v2H0V6zm0 5h18v2H0v-2zm0 5h18v2H0v-2z"/>
+</svg></button>
+            <ul id="search-type-ahead" class="hidden">
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">SyntaxError</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSV</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv_record</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSVRecord</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">record</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.field"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">field</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.string"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.u64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">u64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.f64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">f64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">F64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSV</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv_record</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSVRecord</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.file"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">file</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">CSV</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVRecord"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVRecord</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">CSVField</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVField"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVField</span> <span class="type-ahead-signature">: <span class="type">Utf8</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">request</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Request</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">response</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Response</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Method"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Method</span> <span class="type-ahead-signature">: [<span class="type">Options</span>, <span class="type">Get</span>, <span class="type">Post</span>, <span class="type">Put</span>, <span class="type">Delete</span>, <span class="type">Head</span>, <span class="type">Trace</span>, <span class="type">Connect</span>, <span class="type">Patch</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.HttpVersion"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">HttpVersion</span> <span class="type-ahead-signature">: { major : <span class="type">U8</span>, minor : <span class="type">U8</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Header"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Header</span> <span class="type-ahead-signature">: [<span class="type">Header</span>(<span class="type">Str</span>, <span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Request</span> <span class="type-ahead-signature">: { method : <span class="type">Method</span>, uri : <span class="type">Str</span>, http_version : <span class="type">HttpVersion</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Response</span> <span class="type-ahead-signature">: { http_version : <span class="type">HttpVersion</span>, status_code : <span class="type">U16</span>, status : <span class="type">Str</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.all"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">all</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">Markdown</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.heading"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">heading</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.link"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">link</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.image"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">image</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.code"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">code</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.Level"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">Level</span> <span class="type-ahead-signature">: [<span class="type">One</span>, <span class="type">Two</span>, <span class="type">Three</span>, <span class="type">Four</span>, <span class="type">Five</span>, <span class="type">Six</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.build_primitive_parser"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">build_primitive_parser</span> <span class="type-ahead-signature">: (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse_partial"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span>, (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type-var">input</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.fail"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">fail</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, _)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.const"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">const</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.alt"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">alt</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.apply"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">apply</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_of"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map2"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map2</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map3"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map3</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>), (<span class="type-var">a</span>, <span class="type-var">b</span>, <span class="type-var">c</span><span class="sig-arrow"> -&gt; </span><span class="type-var">d</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">d</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.flatten"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">flatten</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, <span class="type">Str</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.lazy"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">lazy</span> <span class="type-ahead-signature">: ({  }<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.maybe"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">maybe</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">Nothing</span>]))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.many"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">many</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_or_more"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_or_more</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.between"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">between</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">open</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">close</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by1"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by1</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ignore"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ignore</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, {  })</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.keep"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">keep</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.skip"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">skip</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, _)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_until"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_until</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>)) <span class="kw">where</span> { <span class="type-var">a</span>.is_eq : <span class="type-var">a</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_while"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_while</span> <span class="type-ahead-signature">: (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ParseResult"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ParseResult</span> <span class="type-ahead-signature">: <span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type-var">input</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Str</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Utf8</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit_satisfies"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit_satisfies</span> <span class="type-ahead-signature">: (<span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">U8</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_codeunit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_thing"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_thing</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Utf8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digits"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digits</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.one_of"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_utf8</span> <span class="type-ahead-signature">: <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_ascii"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_ascii</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.Utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">Utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.xml_parser"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">xml_parser</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Xml</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Attribute"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Attribute</span> <span class="type-ahead-signature">: { name : <span class="type">Str</span>, value : <span class="type">Str</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Declaration"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Declaration</span> <span class="type-ahead-signature">: { version : <span class="type">Version</span>, encoding : [<span class="type">Given</span>(<span class="type">Encoding</span>), <span class="type">Missing</span>] }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Version</span> <span class="type-ahead-signature"></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.new"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">new</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Version</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.is_eq"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">is_eq</span> <span class="type-ahead-signature">: <span class="type">Version</span>, <span class="type">Version</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Encoding"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Encoding</span> <span class="type-ahead-signature">: [<span class="type">Utf8Encoding</span>, <span class="type">OtherEncoding</span>(<span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Node"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Node</span> <span class="type-ahead-signature">:= [<span class="type">Element</span>(<span class="type">Str</span>, <span class="type">List</span>({ name : <span class="type">Str</span>, value : <span class="type">Str</span> }), <span class="type">List</span>(<span class="type">Node</span>)), <span class="type">Text</span>(<span class="type">Str</span>)]</span></a></li>
+            </ul>
+        </form>
+        <div class="main-content">
+        <h1 class="module-name">Parser</h1>
+        <article class="entry entry-value" id="Parser.build_primitive_parser">
+            <div class="entry-signature">
+                <a href="#Parser.build_primitive_parser" class="entry-anchor" aria-label="Permalink to build_primitive_parser"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.build_primitive_parser" class="entry-name-link"><strong>build_primitive_parser</strong></a> : (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.parse_partial">
+            <div class="entry-signature">
+                <a href="#Parser.parse_partial" class="entry-anchor" aria-label="Permalink to parse_partial"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.parse_partial" class="entry-name-link"><strong>parse_partial</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.parse">
+            <div class="entry-signature">
+                <a href="#Parser.parse" class="entry-anchor" aria-label="Permalink to parse"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.parse" class="entry-name-link"><strong>parse</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span>, (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Bool"><span class="type">Bool</span></a>)<span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">ParsingIncomplete</span>(<span class="type-var">input</span>)])</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.fail">
+            <div class="entry-signature">
+                <a href="#Parser.fail" class="entry-anchor" aria-label="Permalink to fail"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.fail" class="entry-name-link"><strong>fail</strong></a> : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, _)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.const">
+            <div class="entry-signature">
+                <a href="#Parser.const" class="entry-anchor" aria-label="Permalink to const"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.const" class="entry-name-link"><strong>const</strong></a> : <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.alt">
+            <div class="entry-signature">
+                <a href="#Parser.alt" class="entry-anchor" aria-label="Permalink to alt"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.alt" class="entry-name-link"><strong>alt</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.apply">
+            <div class="entry-signature">
+                <a href="#Parser.apply" class="entry-anchor" aria-label="Permalink to apply"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.apply" class="entry-name-link"><strong>apply</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.one_of">
+            <div class="entry-signature">
+                <a href="#Parser.one_of" class="entry-anchor" aria-label="Permalink to one_of"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.one_of" class="entry-name-link"><strong>one_of</strong></a> : <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.map">
+            <div class="entry-signature">
+                <a href="#Parser.map" class="entry-anchor" aria-label="Permalink to map"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.map" class="entry-name-link"><strong>map</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.map2">
+            <div class="entry-signature">
+                <a href="#Parser.map2" class="entry-anchor" aria-label="Permalink to map2"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.map2" class="entry-name-link"><strong>map2</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.map3">
+            <div class="entry-signature">
+                <a href="#Parser.map3" class="entry-anchor" aria-label="Permalink to map3"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.map3" class="entry-name-link"><strong>map3</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>), (<span class="type-var">a</span>, <span class="type-var">b</span>, <span class="type-var">c</span><span class="sig-arrow"> -&gt; </span><span class="type-var">d</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">d</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.flatten">
+            <div class="entry-signature">
+                <a href="#Parser.flatten" class="entry-anchor" aria-label="Permalink to flatten"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.flatten" class="entry-name-link"><strong>flatten</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<span class="type-var">a</span>, <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.lazy">
+            <div class="entry-signature">
+                <a href="#Parser.lazy" class="entry-anchor" aria-label="Permalink to lazy"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.lazy" class="entry-name-link"><strong>lazy</strong></a> : ({  }<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.maybe">
+            <div class="entry-signature">
+                <a href="#Parser.maybe" class="entry-anchor" aria-label="Permalink to maybe"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.maybe" class="entry-name-link"><strong>maybe</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<span class="type-var">a</span>, [<span class="type">Nothing</span>]))</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.many">
+            <div class="entry-signature">
+                <a href="#Parser.many" class="entry-anchor" aria-label="Permalink to many"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.many" class="entry-name-link"><strong>many</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>))</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.one_or_more">
+            <div class="entry-signature">
+                <a href="#Parser.one_or_more" class="entry-anchor" aria-label="Permalink to one_or_more"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.one_or_more" class="entry-name-link"><strong>one_or_more</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>))</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.between">
+            <div class="entry-signature">
+                <a href="#Parser.between" class="entry-anchor" aria-label="Permalink to between"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.between" class="entry-name-link"><strong>between</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">open</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">close</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.sep_by1">
+            <div class="entry-signature">
+                <a href="#Parser.sep_by1" class="entry-anchor" aria-label="Permalink to sep_by1"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.sep_by1" class="entry-name-link"><strong>sep_by1</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>))</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.sep_by">
+            <div class="entry-signature">
+                <a href="#Parser.sep_by" class="entry-anchor" aria-label="Permalink to sep_by"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.sep_by" class="entry-name-link"><strong>sep_by</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>))</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.ignore">
+            <div class="entry-signature">
+                <a href="#Parser.ignore" class="entry-anchor" aria-label="Permalink to ignore"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.ignore" class="entry-name-link"><strong>ignore</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, {  })</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.keep">
+            <div class="entry-signature">
+                <a href="#Parser.keep" class="entry-anchor" aria-label="Permalink to keep"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.keep" class="entry-name-link"><strong>keep</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.skip">
+            <div class="entry-signature">
+                <a href="#Parser.skip" class="entry-anchor" aria-label="Permalink to skip"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.skip" class="entry-name-link"><strong>skip</strong></a> : <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, _)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.chomp_until">
+            <div class="entry-signature">
+                <a href="#Parser.chomp_until" class="entry-anchor" aria-label="Permalink to chomp_until"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.chomp_until" class="entry-name-link"><strong>chomp_until</strong></a> : <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>), <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>)) <span class="kw">where</span> { <span class="type-var">a</span>.is_eq : <span class="type-var">a</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Bool"><span class="type">Bool</span></a> }</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Parser.chomp_while">
+            <div class="entry-signature">
+                <a href="#Parser.chomp_while" class="entry-anchor" aria-label="Permalink to chomp_while"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.chomp_while" class="entry-name-link"><strong>chomp_while</strong></a> : (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Bool"><span class="type">Bool</span></a>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>), <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>))</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Parser.ParseResult">
+            <div class="entry-signature">
+                <a href="#Parser.ParseResult" class="entry-anchor" aria-label="Permalink to ParseResult"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Parser.ParseResult" class="entry-name-link"><strong>ParseResult</strong></a> : <a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>({ val : <span class="type-var">a</span>, input : <span class="type-var">input</span> }, [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)])</code>
+            </div>
+        </article>
+        </div>
+        <footer><p>Made by people who like to make nice things.</p></footer>
+    </main>
+</body>
+</html>

--- a/www/0.11.0/String/index.html
+++ b/www/0.11.0/String/index.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>String Docs</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+    <link rel="stylesheet" href="../styles.css">
+    <script src="../search.js" defer></script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <symbol id="link-icon" viewBox="0 0 640 512">
+      <path d="M562.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L405.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C189.5 251.2 196 330 246 380c56.5 56.5 148 56.5 204.5 0L562.8 267.7zM43.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C57 372 57 321 88.5 289.5L200.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C416.5 260.8 410 182 360 132c-56.5-56.5-148-56.5-204.5 0L43.2 244.3z"/>
+    </symbol>
+  </defs>
+</svg>
+    <nav id="sidebar-nav">
+        <div class="pkg-and-logo">
+            <a class="logo" href="../"><svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logo-link">
+    <title id="logo-link">Home</title>
+    <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
+</svg></a>
+            <h1 class="pkg-full-name"><a href="../">package</a></h1>
+        </div>
+        <div class="module-links-container">
+            <ul class="module-links">
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="CSV" href="../CSV/"><button class="entry-toggle"></button><span>CSV</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv">parse_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv_record">parse_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.record">record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.field">field</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.string">string</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.u64">u64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.f64">f64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv">parse_str_to_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv_record">parse_str_to_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.file">file</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVRecord">CSVRecord</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVField">CSVField</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="HTTP" href="../HTTP/"><button class="entry-toggle"></button><span>HTTP</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.request">request</a></li>
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.response">response</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Method">Method</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.HttpVersion">HttpVersion</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Header">Header</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Request">Request</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Response">Response</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Markdown" href="../Markdown/"><button class="entry-toggle"></button><span>Markdown</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.all">all</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.heading">heading</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.link">link</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.image">image</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.code">code</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Markdown/#Markdown.Level">Level</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Parser" href="../Parser/"><button class="entry-toggle"></button><span>Parser</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Parser/#Parser.build_primitive_parser">build_primitive_parser</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse_partial">parse_partial</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse">parse</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.fail">fail</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.const">const</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.alt">alt</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.apply">apply</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map">map</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map2">map2</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map3">map3</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.flatten">flatten</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.lazy">lazy</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.maybe">maybe</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.many">many</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_or_more">one_or_more</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.between">between</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by1">sep_by1</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by">sep_by</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.ignore">ignore</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.keep">keep</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.skip">skip</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_until">chomp_until</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_while">chomp_while</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Parser/#Parser.ParseResult">ParseResult</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link active" data-module-name="String" href="../String/"><button class="entry-toggle"></button><span>String</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../String/#String.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_str_partial">parse_str_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8">parse_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8_partial">parse_utf8_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit_satisfies">codeunit_satisfies</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit">codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.utf8">utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.string">string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_codeunit">any_codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_thing">any_thing</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_string">any_string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digit">digit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digits">digits</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_utf8">str_from_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_ascii">str_from_ascii</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../String/#String.Utf8">Utf8</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Xml" href="../Xml/"><button class="entry-toggle"></button><span>Xml</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Xml/#Xml.xml_parser">xml_parser</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Attribute">Attribute</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Declaration">Declaration</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Version">Version</a>
+                          <ul class="sidebar-sub-entries">
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.new">new</a></li>
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.is_eq">is_eq</a></li>
+                          </ul>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Encoding">Encoding</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Node">Node</a>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <main>
+        <form id="module-search-form">
+            <input type="search" id="module-search" placeholder="Search Documentation" autocomplete="off" />
+            <input type="search" id="module-search-nojs" placeholder="Enable JavaScript to search" autocomplete="off" disabled aria-label="Search requires JavaScript" />
+            <noscript><style>#module-search{display:none}#module-search-nojs{display:block}</style></noscript>
+            <button class="menu-toggle" type="button" aria-label="Toggle sidebar"><svg viewBox="0 6 18 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 6h18v2H0V6zm0 5h18v2H0v-2zm0 5h18v2H0v-2z"/>
+</svg></button>
+            <ul id="search-type-ahead" class="hidden">
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">SyntaxError</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSV</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv_record</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSVRecord</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">record</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.field"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">field</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.string"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.u64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">u64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.f64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">f64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">F64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSV</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv_record</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSVRecord</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.file"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">file</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">CSV</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVRecord"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVRecord</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">CSVField</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVField"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVField</span> <span class="type-ahead-signature">: <span class="type">Utf8</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">request</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Request</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">response</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Response</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Method"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Method</span> <span class="type-ahead-signature">: [<span class="type">Options</span>, <span class="type">Get</span>, <span class="type">Post</span>, <span class="type">Put</span>, <span class="type">Delete</span>, <span class="type">Head</span>, <span class="type">Trace</span>, <span class="type">Connect</span>, <span class="type">Patch</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.HttpVersion"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">HttpVersion</span> <span class="type-ahead-signature">: { major : <span class="type">U8</span>, minor : <span class="type">U8</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Header"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Header</span> <span class="type-ahead-signature">: [<span class="type">Header</span>(<span class="type">Str</span>, <span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Request</span> <span class="type-ahead-signature">: { method : <span class="type">Method</span>, uri : <span class="type">Str</span>, http_version : <span class="type">HttpVersion</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Response</span> <span class="type-ahead-signature">: { http_version : <span class="type">HttpVersion</span>, status_code : <span class="type">U16</span>, status : <span class="type">Str</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.all"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">all</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">Markdown</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.heading"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">heading</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.link"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">link</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.image"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">image</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.code"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">code</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.Level"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">Level</span> <span class="type-ahead-signature">: [<span class="type">One</span>, <span class="type">Two</span>, <span class="type">Three</span>, <span class="type">Four</span>, <span class="type">Five</span>, <span class="type">Six</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.build_primitive_parser"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">build_primitive_parser</span> <span class="type-ahead-signature">: (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse_partial"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span>, (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type-var">input</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.fail"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">fail</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, _)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.const"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">const</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.alt"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">alt</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.apply"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">apply</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_of"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map2"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map2</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map3"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map3</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>), (<span class="type-var">a</span>, <span class="type-var">b</span>, <span class="type-var">c</span><span class="sig-arrow"> -&gt; </span><span class="type-var">d</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">d</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.flatten"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">flatten</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, <span class="type">Str</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.lazy"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">lazy</span> <span class="type-ahead-signature">: ({  }<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.maybe"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">maybe</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">Nothing</span>]))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.many"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">many</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_or_more"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_or_more</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.between"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">between</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">open</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">close</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by1"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by1</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ignore"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ignore</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, {  })</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.keep"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">keep</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.skip"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">skip</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, _)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_until"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_until</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>)) <span class="kw">where</span> { <span class="type-var">a</span>.is_eq : <span class="type-var">a</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_while"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_while</span> <span class="type-ahead-signature">: (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ParseResult"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ParseResult</span> <span class="type-ahead-signature">: <span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type-var">input</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Str</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Utf8</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit_satisfies"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit_satisfies</span> <span class="type-ahead-signature">: (<span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">U8</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_codeunit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_thing"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_thing</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Utf8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digits"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digits</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.one_of"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_utf8</span> <span class="type-ahead-signature">: <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_ascii"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_ascii</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.Utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">Utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.xml_parser"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">xml_parser</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Xml</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Attribute"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Attribute</span> <span class="type-ahead-signature">: { name : <span class="type">Str</span>, value : <span class="type">Str</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Declaration"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Declaration</span> <span class="type-ahead-signature">: { version : <span class="type">Version</span>, encoding : [<span class="type">Given</span>(<span class="type">Encoding</span>), <span class="type">Missing</span>] }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Version</span> <span class="type-ahead-signature"></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.new"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">new</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Version</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.is_eq"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">is_eq</span> <span class="type-ahead-signature">: <span class="type">Version</span>, <span class="type">Version</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Encoding"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Encoding</span> <span class="type-ahead-signature">: [<span class="type">Utf8Encoding</span>, <span class="type">OtherEncoding</span>(<span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Node"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Node</span> <span class="type-ahead-signature">:= [<span class="type">Element</span>(<span class="type">Str</span>, <span class="type">List</span>({ name : <span class="type">Str</span>, value : <span class="type">Str</span> }), <span class="type">List</span>(<span class="type">Node</span>)), <span class="type">Text</span>(<span class="type">Str</span>)]</span></a></li>
+            </ul>
+        </form>
+        <div class="main-content">
+        <h1 class="module-name">String</h1>
+        <article class="entry entry-value" id="String.parse_str">
+            <div class="entry-signature">
+                <a href="#String.parse_str" class="entry-anchor" aria-label="Permalink to parse_str"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.parse_str" class="entry-name-link"><strong>parse_str</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">ParsingIncomplete</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)])</code>
+            </div>
+            <div class="entry-doc">
+                <p>Parse a <code>Str</code> using a <a href="../Parser/">Parser</a></p>
+                <pre><code>color : Parser(Utf8, [Red, Green, Blue])
+color = {
+    one_of(
+        [
+            Parser.const(Red).skip(string(&quot;red&quot;)),
+            Parser.const(Green).skip(string(&quot;green&quot;)),
+            Parser.const(Blue).skip(string(&quot;blue&quot;)),
+        ]
+    )
+}
+
+expect parse_str(color, &quot;green&quot;) == Ok(Green)</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.parse_str_partial">
+            <div class="entry-signature">
+                <a href="#String.parse_str_partial" class="entry-anchor" aria-label="Permalink to parse_str_partial"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.parse_str_partial" class="entry-name-link"><strong>parse_str_partial</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>({ val : <span class="type-var">a</span>, input : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a> }, [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)])</code>
+            </div>
+            <div class="entry-doc">
+                <p>Runs a parser against the start of a string, allowing the parser to consume it only partially.</p>
+                <p>- If the parser succeeds, returns the resulting value as well as the leftover input.
+- If the parser fails, returns <code>Err (ParsingFailure msg)</code></p>
+                <pre><code>at_sign : Parser(Utf8, [AtSign])
+at_sign = Parser.const(AtSign).skip(codeunit(&#39;@&#39;))
+
+expect parse_str(at_sign, &quot;@&quot;) == Ok(AtSign)
+expect at_sign-&gt;parse_str_partial(&quot;@&quot;).map_ok(|r| { r.val }) == Ok(AtSign)
+expect at_sign-&gt;parse_str_partial(&quot;$&quot;).is_err()</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.parse_utf8">
+            <div class="entry-signature">
+                <a href="#String.parse_utf8" class="entry-anchor" aria-label="Permalink to parse_utf8"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.parse_utf8" class="entry-name-link"><strong>parse_utf8</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</code>
+            </div>
+            <div class="entry-doc">
+                <p>Runs a parser against a string, requiring the parser to consume it fully.</p>
+                <p>- If the parser succeeds, returns <code>Ok a</code>
+- If the parser fails, returns <code>Err (ParsingFailure Str)</code>
+- If the parser succeeds but does not consume the full string, returns <code>Err (ParsingIncomplete (List U8))</code></p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.parse_utf8_partial">
+            <div class="entry-signature">
+                <a href="#String.parse_utf8_partial" class="entry-anchor" aria-label="Permalink to parse_utf8_partial"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.parse_utf8_partial" class="entry-name-link"><strong>parse_utf8_partial</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Try"><span class="type">Try</span></a>({ val : <span class="type-var">a</span>, input : <span class="type">Utf8</span> }, [<span class="type">ParsingFailure</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)])</code>
+            </div>
+            <div class="entry-doc">
+                <p>Runs a parser against the start of a list of scalars, allowing the parser to consume it only partially.</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.codeunit_satisfies">
+            <div class="entry-signature">
+                <a href="#String.codeunit_satisfies" class="entry-anchor" aria-label="Permalink to codeunit_satisfies"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.codeunit_satisfies" class="entry-name-link"><strong>codeunit_satisfies</strong></a> : (<a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Bool"><span class="type">Bool</span></a>)<span class="sig-arrow"> -&gt; </span><a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <pre><code>is_digit : U8 -&gt; Bool
+is_digit = |b| { b &gt;= &#39;0&#39; and b &lt;= &#39;9&#39; }
+
+expect codeunit_satisfies-&gt;parse_str(is_digit, &quot;0&quot;) == Ok(&#39;0&#39;)
+expect codeunit_satisfies-&gt;parse_str(is_digit, &quot;*&quot;).is_err()</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.codeunit">
+            <div class="entry-signature">
+                <a href="#String.codeunit" class="entry-anchor" aria-label="Permalink to codeunit"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.codeunit" class="entry-name-link"><strong>codeunit</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a><span class="sig-arrow"> -&gt; </span><a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <pre><code>at_sign : Parser(Utf8, [AtSign])
+at_sign = Parser.const(AtSign).skip(codeunit(&#39;@&#39;))
+
+expect at_sign-&gt;parse_str(&quot;@&quot;) == Ok(AtSign)
+expect at_sign-&gt;parse_str_partial(&quot;$&quot;).is_err()</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.utf8">
+            <div class="entry-signature">
+                <a href="#String.utf8" class="entry-anchor" aria-label="Permalink to utf8"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.utf8" class="entry-name-link"><strong>utf8</strong></a> : <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>)<span class="sig-arrow"> -&gt; </span><a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>))</code>
+            </div>
+            <div class="entry-doc">
+                <p>Parse an exact sequence of utf8</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.string">
+            <div class="entry-signature">
+                <a href="#String.string" class="entry-anchor" aria-label="Permalink to string"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.string" class="entry-name-link"><strong>string</strong></a> : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a><span class="sig-arrow"> -&gt; </span><a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Parse the given <code>Str</code></p>
+                <pre><code>expect string(&quot;Foo&quot;)-&gt;parse_str(&quot;Foo&quot;) == Ok(&quot;Foo&quot;)
+expect string(&quot;Foo&quot;)-&gt;parse_str(&quot;Bar&quot;).is_err()</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.any_codeunit">
+            <div class="entry-signature">
+                <a href="#String.any_codeunit" class="entry-anchor" aria-label="Permalink to any_codeunit"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.any_codeunit" class="entry-name-link"><strong>any_codeunit</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Matches any <code>U8</code> codeunit</p>
+                <pre><code>expect parse_str(any_codeunit, &quot;a&quot;) == Ok(&#39;a&#39;)
+expect parse_str(any_codeunit, &quot;$&quot;) == Ok(&#39;$&#39;)</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.any_thing">
+            <div class="entry-signature">
+                <a href="#String.any_thing" class="entry-anchor" aria-label="Permalink to any_thing"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.any_thing" class="entry-name-link"><strong>any_thing</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <span class="type">Utf8</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Matches any <code>Utf8</code> and consumes all the input without fail.</p>
+                <pre><code>expect {
+    bytes = &quot;consumes all the input&quot;.to_utf8()
+    any_thing.parse(bytes, List.is_empty) == Ok(bytes)
+}</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.any_string">
+            <div class="entry-signature">
+                <a href="#String.any_string" class="entry-anchor" aria-label="Permalink to any_string"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.any_string" class="entry-name-link"><strong>any_string</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)</code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.digit">
+            <div class="entry-signature">
+                <a href="#String.digit" class="entry-anchor" aria-label="Permalink to digit"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.digit" class="entry-name-link"><strong>digit</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <a href="https://roc-lang.org/builtins/main/Num#U64"><span class="type">U64</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <pre><code>expect digit-&gt;parse_str(&quot;0&quot;) == Ok(0)
+expect digit-&gt;parse_str(&quot;not a digit&quot;).is_err()</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.digits">
+            <div class="entry-signature">
+                <a href="#String.digits" class="entry-anchor" aria-label="Permalink to digits"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.digits" class="entry-name-link"><strong>digits</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <a href="https://roc-lang.org/builtins/main/Num#U64"><span class="type">U64</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Parse a sequence of digits into a <code>U64</code>, accepting leading zeroes</p>
+                <pre><code>expect digits-&gt;parse_str(&quot;0123&quot;) == Ok(123)
+expect digits-&gt;parse_str(&quot;not a digit&quot;).is_err()</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.one_of">
+            <div class="entry-signature">
+                <a href="#String.one_of" class="entry-anchor" aria-label="Permalink to one_of"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.one_of" class="entry-name-link"><strong>one_of</strong></a> : <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<span class="type">Utf8</span>, <span class="type-var">a</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Try a bunch of different parsers.</p>
+                <p>The first parser which is tried is the one at the front of the list,
+and the next one is tried until one succeeds or the end of the list was reached.</p>
+                <pre><code>bool_parser : Parser(Utf8, Bool)
+bool_parser = {
+    one_of([string(&quot;true&quot;), string(&quot;false&quot;)])
+    .map(|x| { x == &quot;true&quot; })
+}
+
+expect bool_parser-&gt;parse_str(&quot;true&quot;) == Ok(Bool.True)
+expect bool_parser-&gt;parse_str(&quot;false&quot;) == Ok(Bool.False)
+expect bool_parser-&gt;parse_str(&quot;not a bool&quot;).is_err()</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.str_from_utf8">
+            <div class="entry-signature">
+                <a href="#String.str_from_utf8" class="entry-anchor" aria-label="Permalink to str_from_utf8"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.str_from_utf8" class="entry-name-link"><strong>str_from_utf8</strong></a> : <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a></code>
+            </div>
+        </article>
+        <article class="entry entry-value" id="String.str_from_ascii">
+            <div class="entry-signature">
+                <a href="#String.str_from_ascii" class="entry-anchor" aria-label="Permalink to str_from_ascii"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.str_from_ascii" class="entry-name-link"><strong>str_from_ascii</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a></code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="String.Utf8">
+            <div class="entry-signature">
+                <a href="#String.Utf8" class="entry-anchor" aria-label="Permalink to Utf8"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#String.Utf8" class="entry-name-link"><strong>Utf8</strong></a> : <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <pre><code>Utf8 : List U8</code></pre>
+            </div>
+        </article>
+        </div>
+        <footer><p>Made by people who like to make nice things.</p></footer>
+    </main>
+</body>
+</html>

--- a/www/0.11.0/Xml/index.html
+++ b/www/0.11.0/Xml/index.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Xml Docs</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+    <link rel="stylesheet" href="../styles.css">
+    <script src="../search.js" defer></script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <symbol id="link-icon" viewBox="0 0 640 512">
+      <path d="M562.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L405.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C189.5 251.2 196 330 246 380c56.5 56.5 148 56.5 204.5 0L562.8 267.7zM43.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C57 372 57 321 88.5 289.5L200.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C416.5 260.8 410 182 360 132c-56.5-56.5-148-56.5-204.5 0L43.2 244.3z"/>
+    </symbol>
+  </defs>
+</svg>
+    <nav id="sidebar-nav">
+        <div class="pkg-and-logo">
+            <a class="logo" href="../"><svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logo-link">
+    <title id="logo-link">Home</title>
+    <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
+</svg></a>
+            <h1 class="pkg-full-name"><a href="../">package</a></h1>
+        </div>
+        <div class="module-links-container">
+            <ul class="module-links">
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="CSV" href="../CSV/"><button class="entry-toggle"></button><span>CSV</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv">parse_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_csv_record">parse_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.record">record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.field">field</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.string">string</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.u64">u64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.f64">f64</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv">parse_str_to_csv</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.parse_str_to_csv_record">parse_str_to_csv_record</a></li>
+                        <li><a class="sidebar-value" href="../CSV/#CSV.file">file</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVRecord">CSVRecord</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../CSV/#CSV.CSVField">CSVField</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="HTTP" href="../HTTP/"><button class="entry-toggle"></button><span>HTTP</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.request">request</a></li>
+                        <li><a class="sidebar-value" href="../HTTP/#HTTP.response">response</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Method">Method</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.HttpVersion">HttpVersion</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Header">Header</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Request">Request</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../HTTP/#HTTP.Response">Response</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Markdown" href="../Markdown/"><button class="entry-toggle"></button><span>Markdown</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.all">all</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.heading">heading</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.link">link</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.image">image</a></li>
+                        <li><a class="sidebar-value" href="../Markdown/#Markdown.code">code</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Markdown/#Markdown.Level">Level</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Parser" href="../Parser/"><button class="entry-toggle"></button><span>Parser</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Parser/#Parser.build_primitive_parser">build_primitive_parser</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse_partial">parse_partial</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.parse">parse</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.fail">fail</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.const">const</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.alt">alt</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.apply">apply</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map">map</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map2">map2</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.map3">map3</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.flatten">flatten</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.lazy">lazy</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.maybe">maybe</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.many">many</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.one_or_more">one_or_more</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.between">between</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by1">sep_by1</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.sep_by">sep_by</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.ignore">ignore</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.keep">keep</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.skip">skip</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_until">chomp_until</a></li>
+                        <li><a class="sidebar-value" href="../Parser/#Parser.chomp_while">chomp_while</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Parser/#Parser.ParseResult">ParseResult</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="String" href="../String/"><button class="entry-toggle"></button><span>String</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../String/#String.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_str_partial">parse_str_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8">parse_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.parse_utf8_partial">parse_utf8_partial</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit_satisfies">codeunit_satisfies</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.codeunit">codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.utf8">utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.string">string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_codeunit">any_codeunit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_thing">any_thing</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.any_string">any_string</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digit">digit</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.digits">digits</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_utf8">str_from_utf8</a></li>
+                        <li><a class="sidebar-value" href="../String/#String.str_from_ascii">str_from_ascii</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../String/#String.Utf8">Utf8</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link active" data-module-name="Xml" href="../Xml/"><button class="entry-toggle"></button><span>Xml</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="../Xml/#Xml.xml_parser">xml_parser</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Attribute">Attribute</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Declaration">Declaration</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Version">Version</a>
+                          <ul class="sidebar-sub-entries">
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.new">new</a></li>
+                          <li><a class="sidebar-value" href="../Xml/#Xml.Version.is_eq">is_eq</a></li>
+                          </ul>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Encoding">Encoding</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="../Xml/#Xml.Node">Node</a>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <main>
+        <form id="module-search-form">
+            <input type="search" id="module-search" placeholder="Search Documentation" autocomplete="off" />
+            <input type="search" id="module-search-nojs" placeholder="Enable JavaScript to search" autocomplete="off" disabled aria-label="Search requires JavaScript" />
+            <noscript><style>#module-search{display:none}#module-search-nojs{display:block}</style></noscript>
+            <button class="menu-toggle" type="button" aria-label="Toggle sidebar"><svg viewBox="0 6 18 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 6h18v2H0V6zm0 5h18v2H0v-2zm0 5h18v2H0v-2z"/>
+</svg></button>
+            <ul id="search-type-ahead" class="hidden">
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">SyntaxError</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSV</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv_record</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSVRecord</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">record</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.field"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">field</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.string"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.u64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">u64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.f64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">f64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">F64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSV</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.parse_str_to_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv_record</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSVRecord</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.file"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">file</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">CSV</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVRecord"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVRecord</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">CSVField</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../CSV/#CSV.CSVField"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVField</span> <span class="type-ahead-signature">: <span class="type">Utf8</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">request</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Request</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">response</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Response</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Method"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Method</span> <span class="type-ahead-signature">: [<span class="type">Options</span>, <span class="type">Get</span>, <span class="type">Post</span>, <span class="type">Put</span>, <span class="type">Delete</span>, <span class="type">Head</span>, <span class="type">Trace</span>, <span class="type">Connect</span>, <span class="type">Patch</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.HttpVersion"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">HttpVersion</span> <span class="type-ahead-signature">: { major : <span class="type">U8</span>, minor : <span class="type">U8</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Header"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Header</span> <span class="type-ahead-signature">: [<span class="type">Header</span>(<span class="type">Str</span>, <span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Request</span> <span class="type-ahead-signature">: { method : <span class="type">Method</span>, uri : <span class="type">Str</span>, http_version : <span class="type">HttpVersion</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../HTTP/#HTTP.Response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Response</span> <span class="type-ahead-signature">: { http_version : <span class="type">HttpVersion</span>, status_code : <span class="type">U16</span>, status : <span class="type">Str</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.all"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">all</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">Markdown</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.heading"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">heading</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.link"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">link</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.image"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">image</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.code"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">code</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Markdown/#Markdown.Level"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">Level</span> <span class="type-ahead-signature">: [<span class="type">One</span>, <span class="type">Two</span>, <span class="type">Three</span>, <span class="type">Four</span>, <span class="type">Five</span>, <span class="type">Six</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.build_primitive_parser"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">build_primitive_parser</span> <span class="type-ahead-signature">: (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse_partial"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.parse"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span>, (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type-var">input</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.fail"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">fail</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, _)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.const"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">const</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.alt"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">alt</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.apply"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">apply</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_of"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map2"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map2</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.map3"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map3</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>), (<span class="type-var">a</span>, <span class="type-var">b</span>, <span class="type-var">c</span><span class="sig-arrow"> -&gt; </span><span class="type-var">d</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">d</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.flatten"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">flatten</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, <span class="type">Str</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.lazy"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">lazy</span> <span class="type-ahead-signature">: ({  }<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.maybe"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">maybe</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">Nothing</span>]))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.many"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">many</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.one_or_more"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_or_more</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.between"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">between</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">open</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">close</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by1"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by1</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.sep_by"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ignore"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ignore</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, {  })</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.keep"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">keep</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.skip"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">skip</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, _)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_until"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_until</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>)) <span class="kw">where</span> { <span class="type-var">a</span>.is_eq : <span class="type-var">a</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.chomp_while"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_while</span> <span class="type-ahead-signature">: (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Parser/#Parser.ParseResult"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ParseResult</span> <span class="type-ahead-signature">: <span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type-var">input</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_str_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Str</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.parse_utf8_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Utf8</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit_satisfies"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit_satisfies</span> <span class="type-ahead-signature">: (<span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">U8</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_codeunit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_thing"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_thing</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Utf8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.any_string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.digits"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digits</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.one_of"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_utf8</span> <span class="type-ahead-signature">: <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.str_from_ascii"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_ascii</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../String/#String.Utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">Utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.xml_parser"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">xml_parser</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Xml</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Attribute"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Attribute</span> <span class="type-ahead-signature">: { name : <span class="type">Str</span>, value : <span class="type">Str</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Declaration"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Declaration</span> <span class="type-ahead-signature">: { version : <span class="type">Version</span>, encoding : [<span class="type">Given</span>(<span class="type">Encoding</span>), <span class="type">Missing</span>] }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Version</span> <span class="type-ahead-signature"></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.new"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">new</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Version</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Version.is_eq"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">is_eq</span> <span class="type-ahead-signature">: <span class="type">Version</span>, <span class="type">Version</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Encoding"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Encoding</span> <span class="type-ahead-signature">: [<span class="type">Utf8Encoding</span>, <span class="type">OtherEncoding</span>(<span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="../Xml/#Xml.Node"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Node</span> <span class="type-ahead-signature">:= [<span class="type">Element</span>(<span class="type">Str</span>, <span class="type">List</span>({ name : <span class="type">Str</span>, value : <span class="type">Str</span> }), <span class="type">List</span>(<span class="type">Node</span>)), <span class="type">Text</span>(<span class="type">Str</span>)]</span></a></li>
+            </ul>
+        </form>
+        <div class="main-content">
+        <h1 class="module-name">Xml</h1>
+        <article class="entry entry-value" id="Xml.xml_parser">
+            <div class="entry-signature">
+                <a href="#Xml.xml_parser" class="entry-anchor" aria-label="Permalink to xml_parser"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Xml.xml_parser" class="entry-name-link"><strong>xml_parser</strong></a> : <a href="../Parser/#Parser.Parser"><span class="type">Parser</span></a>(<a href="../String/#String.Utf8"><span class="type">Utf8</span></a>, <span class="type">Xml</span>)</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Xml.Attribute">
+            <div class="entry-signature">
+                <a href="#Xml.Attribute" class="entry-anchor" aria-label="Permalink to Attribute"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Xml.Attribute" class="entry-name-link"><strong>Attribute</strong></a> : { name : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>, value : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a> }</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Xml.Declaration">
+            <div class="entry-signature">
+                <a href="#Xml.Declaration" class="entry-anchor" aria-label="Permalink to Declaration"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Xml.Declaration" class="entry-name-link"><strong>Declaration</strong></a> : { version : <span class="type">Version</span>, encoding : [<span class="type">Given</span>(<span class="type">Encoding</span>), <span class="type">Missing</span>] }</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Xml.Version">
+            <h2><a href="#Xml.Version" class="entry-anchor" aria-label="Permalink to Version"><svg class="link-icon"><use href="#link-icon"/></svg></a> <a href="#Xml.Version" class="entry-name-link">Version</a></h2>
+            <div class="entry-children-container">
+                <article class="entry entry-value" id="Xml.Version.new">
+                    <div class="entry-signature">
+                        <a href="#Xml.Version.new" class="entry-anchor" aria-label="Permalink to new"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                        <code class="entry-signature-code"><a href="#Xml.Version.new" class="entry-name-link"><strong>new</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a><span class="sig-arrow"> -&gt; </span><span class="type">Version</span></code>
+                    </div>
+                </article>
+                <article class="entry entry-value" id="Xml.Version.is_eq">
+                    <div class="entry-signature">
+                        <a href="#Xml.Version.is_eq" class="entry-anchor" aria-label="Permalink to is_eq"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                        <code class="entry-signature-code"><a href="#Xml.Version.is_eq" class="entry-name-link"><strong>is_eq</strong></a> : <span class="type">Version</span>, <span class="type">Version</span><span class="sig-arrow"> -&gt; </span><a href="https://roc-lang.org/builtins/main/Bool"><span class="type">Bool</span></a></code>
+                    </div>
+                </article>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Xml.Encoding">
+            <div class="entry-signature">
+                <a href="#Xml.Encoding" class="entry-anchor" aria-label="Permalink to Encoding"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Xml.Encoding" class="entry-name-link"><strong>Encoding</strong></a> : [<span class="type">Utf8Encoding</span>, <span class="type">OtherEncoding</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)]</code>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Xml.Node">
+            <h2><a href="#Xml.Node" class="entry-anchor" aria-label="Permalink to Node"><svg class="link-icon"><use href="#link-icon"/></svg></a> <a href="#Xml.Node" class="entry-name-link">Node</a></h2>
+            <code class="entry-type-def">:= [<span class="type">Element</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>, <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>({ name : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>, value : <a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a> }), <a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type">Node</span>)), <span class="type">Text</span>(<a href="https://roc-lang.org/builtins/main/Str"><span class="type">Str</span></a>)]</code>
+        </article>
+        </div>
+        <footer><p>Made by people who like to make nice things.</p></footer>
+    </main>
+</body>
+</html>

--- a/www/0.11.0/favicon.svg
+++ b/www/0.11.0/favicon.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 52 53" xmlns="http://www.w3.org/2000/svg">
+  <!-- Make this icon look nicer in dark mode. (Only Firefox supports this; others ignore it.) -->
+  <style>@media (prefers-color-scheme: dark){polygon{fill:#9c7bea}}</style>
+  <polygon fill="#7d59dd" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086"/>
+</svg>

--- a/www/0.11.0/index.html
+++ b/www/0.11.0/index.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>package Docs</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="stylesheet" href="styles.css">
+    <script src="search.js" defer></script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <symbol id="link-icon" viewBox="0 0 640 512">
+      <path d="M562.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L405.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C189.5 251.2 196 330 246 380c56.5 56.5 148 56.5 204.5 0L562.8 267.7zM43.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C57 372 57 321 88.5 289.5L200.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C416.5 260.8 410 182 360 132c-56.5-56.5-148-56.5-204.5 0L43.2 244.3z"/>
+    </symbol>
+  </defs>
+</svg>
+    <nav id="sidebar-nav">
+        <div class="pkg-and-logo">
+            <a class="logo" href="."><svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logo-link">
+    <title id="logo-link">Home</title>
+    <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
+</svg></a>
+            <h1 class="pkg-full-name"><a href="">package</a></h1>
+        </div>
+        <div class="module-links-container">
+            <ul class="module-links">
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="CSV" href="CSV/"><button class="entry-toggle"></button><span>CSV</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="CSV/#CSV.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.parse_csv">parse_csv</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.parse_csv_record">parse_csv_record</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.record">record</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.field">field</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.string">string</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.u64">u64</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.f64">f64</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.parse_str_to_csv">parse_str_to_csv</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.parse_str_to_csv_record">parse_str_to_csv_record</a></li>
+                        <li><a class="sidebar-value" href="CSV/#CSV.file">file</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="CSV/#CSV.CSVRecord">CSVRecord</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="CSV/#CSV.CSVField">CSVField</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="HTTP" href="HTTP/"><button class="entry-toggle"></button><span>HTTP</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="HTTP/#HTTP.request">request</a></li>
+                        <li><a class="sidebar-value" href="HTTP/#HTTP.response">response</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="HTTP/#HTTP.Method">Method</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="HTTP/#HTTP.HttpVersion">HttpVersion</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="HTTP/#HTTP.Header">Header</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="HTTP/#HTTP.Request">Request</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="HTTP/#HTTP.Response">Response</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Markdown" href="Markdown/"><button class="entry-toggle"></button><span>Markdown</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="Markdown/#Markdown.all">all</a></li>
+                        <li><a class="sidebar-value" href="Markdown/#Markdown.heading">heading</a></li>
+                        <li><a class="sidebar-value" href="Markdown/#Markdown.link">link</a></li>
+                        <li><a class="sidebar-value" href="Markdown/#Markdown.image">image</a></li>
+                        <li><a class="sidebar-value" href="Markdown/#Markdown.code">code</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="Markdown/#Markdown.Level">Level</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Parser" href="Parser/"><button class="entry-toggle"></button><span>Parser</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="Parser/#Parser.build_primitive_parser">build_primitive_parser</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.parse_partial">parse_partial</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.parse">parse</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.fail">fail</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.const">const</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.alt">alt</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.apply">apply</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.map">map</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.map2">map2</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.map3">map3</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.flatten">flatten</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.lazy">lazy</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.maybe">maybe</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.many">many</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.one_or_more">one_or_more</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.between">between</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.sep_by1">sep_by1</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.sep_by">sep_by</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.ignore">ignore</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.keep">keep</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.skip">skip</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.chomp_until">chomp_until</a></li>
+                        <li><a class="sidebar-value" href="Parser/#Parser.chomp_while">chomp_while</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="Parser/#Parser.ParseResult">ParseResult</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="String" href="String/"><button class="entry-toggle"></button><span>String</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="String/#String.parse_str">parse_str</a></li>
+                        <li><a class="sidebar-value" href="String/#String.parse_str_partial">parse_str_partial</a></li>
+                        <li><a class="sidebar-value" href="String/#String.parse_utf8">parse_utf8</a></li>
+                        <li><a class="sidebar-value" href="String/#String.parse_utf8_partial">parse_utf8_partial</a></li>
+                        <li><a class="sidebar-value" href="String/#String.codeunit_satisfies">codeunit_satisfies</a></li>
+                        <li><a class="sidebar-value" href="String/#String.codeunit">codeunit</a></li>
+                        <li><a class="sidebar-value" href="String/#String.utf8">utf8</a></li>
+                        <li><a class="sidebar-value" href="String/#String.string">string</a></li>
+                        <li><a class="sidebar-value" href="String/#String.any_codeunit">any_codeunit</a></li>
+                        <li><a class="sidebar-value" href="String/#String.any_thing">any_thing</a></li>
+                        <li><a class="sidebar-value" href="String/#String.any_string">any_string</a></li>
+                        <li><a class="sidebar-value" href="String/#String.digit">digit</a></li>
+                        <li><a class="sidebar-value" href="String/#String.digits">digits</a></li>
+                        <li><a class="sidebar-value" href="String/#String.one_of">one_of</a></li>
+                        <li><a class="sidebar-value" href="String/#String.str_from_utf8">str_from_utf8</a></li>
+                        <li><a class="sidebar-value" href="String/#String.str_from_ascii">str_from_ascii</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="String/#String.Utf8">Utf8</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link" data-module-name="Xml" href="Xml/"><button class="entry-toggle"></button><span>Xml</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="Xml/#Xml.xml_parser">xml_parser</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="Xml/#Xml.Attribute">Attribute</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="Xml/#Xml.Declaration">Declaration</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="Xml/#Xml.Version">Version</a>
+                          <ul class="sidebar-sub-entries">
+                          <li><a class="sidebar-value" href="Xml/#Xml.Version.new">new</a></li>
+                          <li><a class="sidebar-value" href="Xml/#Xml.Version.is_eq">is_eq</a></li>
+                          </ul>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="Xml/#Xml.Encoding">Encoding</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="Xml/#Xml.Node">Node</a>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <main>
+        <form id="module-search-form">
+            <input type="search" id="module-search" placeholder="Search Documentation" autocomplete="off" />
+            <input type="search" id="module-search-nojs" placeholder="Enable JavaScript to search" autocomplete="off" disabled aria-label="Search requires JavaScript" />
+            <noscript><style>#module-search{display:none}#module-search-nojs{display:block}</style></noscript>
+            <button class="menu-toggle" type="button" aria-label="Toggle sidebar"><svg viewBox="0 6 18 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 6h18v2H0V6zm0 5h18v2H0v-2zm0 5h18v2H0v-2z"/>
+</svg></button>
+            <ul id="search-type-ahead" class="hidden">
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.parse_str"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">SyntaxError</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.parse_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSV</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">List</span>(<span class="type-var">a</span>), [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.parse_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_csv_record</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>), <span class="type">CSVRecord</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">CSVRecord</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">record</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.field"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">field</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">CSVRecord</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.string"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.u64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">u64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.f64"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">f64</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">CSVField</span>, <span class="type">F64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.parse_str_to_csv"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSV</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.parse_str_to_csv_record"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">parse_str_to_csv_record</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type">CSVRecord</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.file"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">file</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">CSV</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.CSVRecord"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVRecord</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">CSVField</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="CSV/#CSV.CSVField"><span class="type-ahead-module-name">CSV</span>.<span class="type-ahead-def-name">CSVField</span> <span class="type-ahead-signature">: <span class="type">Utf8</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="HTTP/#HTTP.request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">request</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Request</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="HTTP/#HTTP.response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">response</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Response</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="HTTP/#HTTP.Method"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Method</span> <span class="type-ahead-signature">: [<span class="type">Options</span>, <span class="type">Get</span>, <span class="type">Post</span>, <span class="type">Put</span>, <span class="type">Delete</span>, <span class="type">Head</span>, <span class="type">Trace</span>, <span class="type">Connect</span>, <span class="type">Patch</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="HTTP/#HTTP.HttpVersion"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">HttpVersion</span> <span class="type-ahead-signature">: { major : <span class="type">U8</span>, minor : <span class="type">U8</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="HTTP/#HTTP.Header"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Header</span> <span class="type-ahead-signature">: [<span class="type">Header</span>(<span class="type">Str</span>, <span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="HTTP/#HTTP.Request"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Request</span> <span class="type-ahead-signature">: { method : <span class="type">Method</span>, uri : <span class="type">Str</span>, http_version : <span class="type">HttpVersion</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="HTTP/#HTTP.Response"><span class="type-ahead-module-name">HTTP</span>.<span class="type-ahead-def-name">Response</span> <span class="type-ahead-signature">: { http_version : <span class="type">HttpVersion</span>, status_code : <span class="type">U16</span>, status : <span class="type">Str</span>, headers : <span class="type">List</span>(<span class="type">Header</span>), body : <span class="type">List</span>(<span class="type">U8</span>) }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Markdown/#Markdown.all"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">all</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">Markdown</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Markdown/#Markdown.heading"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">heading</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Markdown/#Markdown.link"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">link</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Markdown/#Markdown.image"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">image</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Markdown/#Markdown.code"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">code</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Markdown</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Markdown/#Markdown.Level"><span class="type-ahead-module-name">Markdown</span>.<span class="type-ahead-def-name">Level</span> <span class="type-ahead-signature">: [<span class="type">One</span>, <span class="type">Two</span>, <span class="type">Three</span>, <span class="type">Four</span>, <span class="type">Five</span>, <span class="type">Six</span>]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.build_primitive_parser"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">build_primitive_parser</span> <span class="type-ahead-signature">: (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.parse_partial"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">ParseResult</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.parse"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">parse</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type-var">input</span>, (<span class="type-var">input</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type-var">input</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.fail"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">fail</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, _)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.const"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">const</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(_, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.alt"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">alt</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.apply"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">apply</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.one_of"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.map"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.map2"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map2</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.map3"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">map3</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">c</span>), (<span class="type-var">a</span>, <span class="type-var">b</span>, <span class="type-var">c</span><span class="sig-arrow"> -&gt; </span><span class="type-var">d</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">d</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.flatten"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">flatten</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, <span class="type">Str</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.lazy"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">lazy</span> <span class="type-ahead-signature">: ({  }<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.maybe"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">maybe</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">Nothing</span>]))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.many"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">many</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.one_or_more"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">one_or_more</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.between"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">between</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">open</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">close</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.sep_by1"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by1</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.sep_by"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">sep_by</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">sep</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.ignore"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ignore</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, {  })</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.keep"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">keep</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.skip"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">skip</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>), <span class="type">Parser</span>(<span class="type-var">input</span>, _)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type-var">input</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.chomp_until"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_until</span> <span class="type-ahead-signature">: <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>)) <span class="kw">where</span> { <span class="type-var">a</span>.is_eq : <span class="type-var">a</span>, <span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.chomp_while"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">chomp_while</span> <span class="type-ahead-signature">: (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">List</span>(<span class="type-var">a</span>), <span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Parser/#Parser.ParseResult"><span class="type-ahead-module-name">Parser</span>.<span class="type-ahead-def-name">ParseResult</span> <span class="type-ahead-signature">: <span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type-var">input</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.parse_str"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.parse_str_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_str_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Str</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.parse_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>(<span class="type-var">a</span>, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>), <span class="type">ParsingIncomplete</span>(<span class="type">Utf8</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.parse_utf8_partial"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">parse_utf8_partial</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>), <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Try</span>({ val : <span class="type-var">a</span>, input : <span class="type">Utf8</span> }, [<span class="type">ParsingFailure</span>(<span class="type">Str</span>)])</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.codeunit_satisfies"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit_satisfies</span> <span class="type-ahead-signature">: (<span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">codeunit</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">List</span>(<span class="type">U8</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">string</span> <span class="type-ahead-signature">: <span class="type">Str</span><span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.any_codeunit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_codeunit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.any_thing"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_thing</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Utf8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.any_string"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">any_string</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Str</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.digit"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digit</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.digits"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">digits</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">U64</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.one_of"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">one_of</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>))<span class="sig-arrow"> -&gt; </span><span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type-var">a</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.str_from_utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_utf8</span> <span class="type-ahead-signature">: <span class="type">Utf8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.str_from_ascii"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">str_from_ascii</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Str</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="String/#String.Utf8"><span class="type-ahead-module-name">String</span>.<span class="type-ahead-def-name">Utf8</span> <span class="type-ahead-signature">: <span class="type">List</span>(<span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Xml/#Xml.xml_parser"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">xml_parser</span> <span class="type-ahead-signature">: <span class="type">Parser</span>(<span class="type">Utf8</span>, <span class="type">Xml</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Xml/#Xml.Attribute"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Attribute</span> <span class="type-ahead-signature">: { name : <span class="type">Str</span>, value : <span class="type">Str</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Xml/#Xml.Declaration"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Declaration</span> <span class="type-ahead-signature">: { version : <span class="type">Version</span>, encoding : [<span class="type">Given</span>(<span class="type">Encoding</span>), <span class="type">Missing</span>] }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Xml/#Xml.Version"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Version</span> <span class="type-ahead-signature"></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Xml/#Xml.Version.new"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">new</span> <span class="type-ahead-signature">: <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Version</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Xml/#Xml.Version.is_eq"><span class="type-ahead-module-name">Xml.Version</span>.<span class="type-ahead-def-name">is_eq</span> <span class="type-ahead-signature">: <span class="type">Version</span>, <span class="type">Version</span><span class="sig-arrow"> -&gt; </span><span class="type">Bool</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Xml/#Xml.Encoding"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Encoding</span> <span class="type-ahead-signature">: [<span class="type">Utf8Encoding</span>, <span class="type">OtherEncoding</span>(<span class="type">Str</span>)]</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="Xml/#Xml.Node"><span class="type-ahead-module-name">Xml</span>.<span class="type-ahead-def-name">Node</span> <span class="type-ahead-signature">:= [<span class="type">Element</span>(<span class="type">Str</span>, <span class="type">List</span>({ name : <span class="type">Str</span>, value : <span class="type">Str</span> }), <span class="type">List</span>(<span class="type">Node</span>)), <span class="type">Text</span>(<span class="type">Str</span>)]</span></a></li>
+            </ul>
+        </form>
+        <div class="main-content">
+        <h1 class="module-name">package</h1>
+        <ul class="index-module-links">
+            <li><a href="CSV/">CSV</a></li>
+            <li><a href="HTTP/">HTTP</a></li>
+            <li><a href="Markdown/">Markdown</a></li>
+            <li><a href="Parser/">Parser</a></li>
+            <li><a href="String/">String</a></li>
+            <li><a href="Xml/">Xml</a></li>
+        </ul>
+        </div>
+        <footer><p>Made by people who like to make nice things.</p></footer>
+    </main>
+</body>
+</html>

--- a/www/0.11.0/search.js
+++ b/www/0.11.0/search.js
@@ -1,0 +1,327 @@
+const toggleSidebarEntryActive = (moduleName) => {
+  let sidebar = document.getElementById("sidebar-nav");
+
+  if (sidebar != null) {
+    // Un-hide everything
+    sidebar.querySelectorAll(".sidebar-entry").forEach((entry) => {
+      let link = entry.querySelector(".sidebar-module-link");
+      if (moduleName === link.dataset.moduleName) {
+        link.classList.toggle("active");
+      }
+    });
+  }
+};
+
+const setupSidebarNav = () => {
+  // Re-hide all the sub-entries except for those of the current module
+  let currentModuleName = document.querySelector(".module-name").textContent;
+  toggleSidebarEntryActive(currentModuleName);
+
+  // Use event delegation for entry toggles and sidebar group toggles
+  document.addEventListener("click", (e) => {
+    // Handle entry toggle buttons
+    if (e.target.classList.contains("entry-toggle")) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const moduleName = e.target.parentElement.dataset.moduleName;
+      toggleSidebarEntryActive(moduleName);
+      return;
+    }
+
+    // Handle sidebar group name clicks — toggle expanded and navigate
+    const groupName = e.target.closest(".sidebar-type-name");
+    if (groupName) {
+      const group = groupName.closest(".sidebar-type");
+      if (group) {
+        group.classList.toggle("expanded");
+      }
+      return;
+    }
+  });
+
+  // Auto-expand groups in the active module
+  const activeModule = document.querySelector(".sidebar-module-link.active");
+  if (activeModule) {
+    const subEntries = activeModule.parentElement?.querySelector(".sidebar-sub-entries");
+    if (subEntries) {
+      // Mark groups in active module as expanded
+      subEntries.querySelectorAll(".sidebar-type").forEach((group) => {
+        group.classList.add("expanded");
+      });
+    }
+  }
+};
+
+const setupSearch = () => {
+  let searchTypeAhead = document.getElementById("search-type-ahead");
+  let searchBox = document.getElementById("module-search");
+  let searchForm = document.getElementById("module-search-form");
+  let topSearchResultListItem = undefined;
+
+  // Hide the results whenever anyone clicks outside the search results,
+  // or on a specific search result.
+  window.addEventListener("click", function (event) {
+    if (!searchForm?.contains(event.target) || event.target.closest("#search-type-ahead a")) {
+      searchTypeAhead.classList.add("hidden");
+    }
+  });
+
+  if (searchBox != null) {
+    function searchKeyDown(event) {
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+
+          const focused = document.querySelector(
+            "#search-type-ahead > li:not([class*='hidden']) > a:focus",
+          );
+
+          // Find the next element to focus.
+          let nextToFocus = focused?.parentElement?.nextElementSibling;
+
+          while (
+            nextToFocus != null &&
+            nextToFocus.classList.contains("hidden")
+          ) {
+            nextToFocus = nextToFocus.nextElementSibling;
+          }
+
+          if (nextToFocus == null) {
+            // If none of the links were focused, focus the first one.
+            // Also if we've reached the last one in the list, wrap around to the first.
+            document
+              .querySelector(
+                "#search-type-ahead > li:not([class*='hidden']) > a",
+              )
+              ?.focus();
+          } else {
+            nextToFocus.querySelector("a").focus();
+          }
+
+          break;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+
+          const focused = document.querySelector(
+            "#search-type-ahead > li:not([class*='hidden']) > a:focus",
+          );
+
+          // Find the next element to focus.
+          let nextToFocus = focused?.parentElement?.previousElementSibling;
+          while (
+            nextToFocus != null &&
+            nextToFocus.classList.contains("hidden")
+          ) {
+            nextToFocus = nextToFocus.previousElementSibling;
+          }
+
+          if (nextToFocus == null) {
+            // If none of the links were focused, or we're at the first one, focus the search box again.
+            searchBox?.focus();
+          } else {
+            // If one of the links was focused, focus the previous one
+            nextToFocus.querySelector("a").focus();
+          }
+
+          break;
+        }
+        case "Enter": {
+          // In case this is just an anchor link (which will move the scroll bar but not
+          // reload the page), hide the search bar.
+          searchTypeAhead.classList.add("hidden");
+          break;
+        }
+      }
+    }
+
+    searchForm.addEventListener("keydown", searchKeyDown);
+
+    function search() {
+      topSearchResultListItem = undefined;
+      let text = searchBox.value.toLowerCase(); // Search is case-insensitive.
+
+      if (text === "") {
+        searchTypeAhead.classList.add("hidden");
+      } else {
+        let totalResults = 0;
+        // Show/hide all the sub-entries within each module (top-level functions etc.)
+        searchTypeAhead.querySelectorAll("li").forEach((entry) => {
+          const entryModule = entry
+            .querySelector(".type-ahead-module-name")
+            ?.textContent?.toLowerCase() ?? "";
+          const entryName = entry
+            .querySelector(".type-ahead-def-name")
+            .textContent.toLowerCase();
+          const entrySignature = entry
+            .querySelector(".type-ahead-signature")
+            ?.textContent?.toLowerCase()
+            ?.replace(/\s+/g, "");
+
+          const qualifiedEntryName = entryModule
+            ? `${entryModule}.${entryName}`
+            : entryName;
+
+          if (
+            qualifiedEntryName.includes(text) ||
+            entrySignature?.includes(text.replace(/\s+/g, ""))
+          ) {
+            totalResults++;
+            entry.classList.remove("hidden");
+            if (topSearchResultListItem === undefined) {
+              topSearchResultListItem = entry;
+            }
+          } else {
+            entry.classList.add("hidden");
+          }
+        });
+        if (totalResults < 1) {
+          searchTypeAhead.classList.add("hidden");
+        } else {
+          searchTypeAhead.classList.remove("hidden");
+        }
+      }
+    }
+
+    searchBox.addEventListener("input", search);
+
+    search();
+
+    function searchSubmit(e) {
+      // pick the top result if the user submits search form
+      e.preventDefault();
+      if (topSearchResultListItem !== undefined) {
+        let topSearchResultListItemAnchor =
+          topSearchResultListItem.querySelector("a");
+        if (topSearchResultListItemAnchor !== null) {
+          topSearchResultListItemAnchor.click();
+        }
+      }
+    }
+    searchForm.addEventListener("submit", searchSubmit);
+
+    // Capture '/' keypress for quick search
+    window.addEventListener("keyup", (e) => {
+      if (e.key === "s" && document.activeElement !== searchBox) {
+        e.preventDefault();
+        searchBox.focus();
+        searchBox.value = "";
+      }
+
+      if (e.key === "Escape") {
+        if (document.activeElement === searchBox) {
+          // De-focus and clear input box
+          searchBox.value = "";
+          searchBox.blur();
+        } else {
+          // Hide the search results
+          searchTypeAhead.classList.add("hidden");
+
+          if (searchTypeAhead.contains(document.activeElement)) {
+            searchBox.focus();
+          }
+        }
+      }
+    });
+  }
+};
+
+const isTouchSupported = () => {
+  try {
+    document.createEvent("TouchEvent");
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+const setupCodeBlocks = () => {
+  // Select all <samp> elements that are children of <pre> elements
+  const codeBlocks = document.querySelectorAll("pre > samp");
+
+  // Iterate over each code block
+  codeBlocks.forEach((codeBlock) => {
+    // Create a "Copy" button
+    const copyButton = document.createElement("button");
+    copyButton.classList.add("copy-button");
+    copyButton.textContent = "Copy";
+
+    // Add event listener to copy button
+    copyButton.addEventListener("click", () => {
+      const codeText = codeBlock.innerText;
+      navigator.clipboard.writeText(codeText);
+      copyButton.textContent = "Copied!";
+      copyButton.classList.add("copy-button-copied");
+      copyButton.addEventListener("mouseleave", () => {
+        copyButton.textContent = "Copy";
+        copyButton.classList.remove("copy-button-copied");
+      });
+    });
+
+    // Create a container for the copy button and append it to the document
+    const buttonContainer = document.createElement("div");
+    buttonContainer.classList.add("button-container");
+    buttonContainer.appendChild(copyButton);
+    codeBlock.parentNode.insertBefore(buttonContainer, codeBlock);
+
+    // Hide the button container by default
+    buttonContainer.style.display = "none";
+
+    if (isTouchSupported()) {
+      // Show the button container on click for touch support (e.g. mobile)
+      document.addEventListener("click", (event) => {
+        if (event.target.closest("pre > samp") !== codeBlock) {
+          buttonContainer.style.display = "none";
+        } else {
+          buttonContainer.style.display = "block";
+        }
+      });
+    } else {
+      // Show the button container on hover for non-touch support (e.g. desktop)
+      codeBlock.parentNode.addEventListener("mouseenter", () => {
+        buttonContainer.style.display = "block";
+      });
+
+      codeBlock.parentNode.addEventListener("mouseleave", () => {
+        buttonContainer.style.display = "none";
+      });
+    }
+  });
+};
+
+const setupSidebarToggle = () => {
+  let body = document.body;
+  const sidebarOpen = "sidebar-open";
+  const removeOpenClass = () => {
+    body.classList.remove(sidebarOpen);
+    document.body
+      .querySelector("main")
+      .removeEventListener("click", removeOpenClass);
+  };
+  Array.from(document.body.querySelectorAll(".menu-toggle")).forEach(
+    (menuToggle) => {
+      menuToggle.addEventListener("click", (e) => {
+        body.classList.toggle(sidebarOpen);
+        e.stopPropagation();
+        if (body.classList.contains(sidebarOpen)) {
+          document.body.addEventListener("click", removeOpenClass);
+        }
+      });
+    },
+  );
+};
+
+// Only run setup functions if their required elements are present
+if (document.querySelector(".module-name")) {
+  setupSidebarNav();
+}
+
+if (document.getElementById("module-search")) {
+  setupSearch();
+}
+
+setupCodeBlocks();
+
+if (document.querySelector(".menu-toggle")) {
+  setupSidebarToggle();
+}

--- a/www/0.11.0/styles.css
+++ b/www/0.11.0/styles.css
@@ -1,0 +1,1240 @@
+:root {
+  /* Sidebar dropdown triangle, used as a mask on `.entry-toggle::before` so it
+     follows the toggle's color. Two back-to-back right triangles split along the
+     triangle's axis; the lower half is masked to ~55% alpha so it reads a touch
+     lighter than the upper half. */
+  --toggle-triangle: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath d='M1.5 1L1.5 4L7 4Z'/%3E%3Cpath d='M1.5 4L1.5 7L7 4Z' fill-opacity='.55'/%3E%3C/svg%3E");
+  /* WCAG AAA Compliant colors - important that luminance (the l in hsl) is 18% for font colors against the bg's luminance of 96-97% when the font-size is at least 14pt */
+  --code-bg: hsl(262 33% 96% / 1);
+  --code-color: #000;
+  --gray: hsl(0 0% 18% / 1);
+  --orange: hsl(25 100% 18% / 1);
+  --green: hsl(115 100% 18% / 1);
+  --cyan: hsl(190 100% 18% / 1);
+  --blue: #05006d;
+  --violet: #7c38f5;
+  --violet-bg: hsl(262.22deg 87.1% 96%);
+  --magenta: #a20031;
+  --link-hover-color: #333;
+  --link-color: var(--violet);
+  --code-link-color: var(--violet);
+  --text-color: #000;
+  --text-hover-color: var(--violet);
+  --body-bg-color: #ffffff;
+  --border-color: #717171;
+  --faded-color: #4c4c4c;
+  --font-sans: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  --sidebar-width: clamp(280px, 25dvw, 500px);
+  --module-search-height: 56px;
+  --module-search-padding-height: 16px;
+  --module-search-form-padding-width: 20px;
+  /* Total vertical space occupied by #module-search-form (input + form padding + margin-bottom).
+     Used both as scroll-padding-top on desktop (sticky form) and padding-top on mobile (fixed form). */
+  --module-search-form-height: calc(var(--module-search-height) + 32px);
+  --sidebar-bg-color: hsl(from var(--violet-bg) h calc(s * 1.05) calc(l * 0.95));
+
+  /* Semantic size tokens */
+  --entry-anchor-offset: 28px; /* space reserved left of entry headings for the permalink anchor */
+  --icon-size: 48px;           /* logo, menu-toggle, entry-toggle tap targets */
+
+  /* Semi-transparent tints derived from palette colors */
+  --violet-border-subtle: rgb(from var(--violet) r g b / .40);
+  --violet-border-hover: rgb(from var(--violet) r g b / .60);
+  --gray-border-subtle: rgb(from var(--gray) r g b / .30);
+
+  /* Search input border — distinct from --violet-bg so it's visible on a white background */
+  --search-border-color: hsl(262 50% 72%);
+
+  /* Type scale: 1.33x multiplier for clear hierarchy */
+  --font-xs: 0.75rem;
+  --font-sm: 0.875rem;
+  --font-base: 1rem;
+  --font-lg: 1.3125rem;
+  --font-xl: 1.75rem;
+  --font-2xl: 2.3125rem;
+
+  /* Font weights */
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+}
+
+
+a {
+  color: var(--violet);
+}
+
+table tr th,
+table tr td {
+  border: 1px solid var(--gray);
+  padding: 6px 13px;
+}
+
+.logo svg {
+  height: var(--icon-size);
+  width: var(--icon-size);
+  fill: var(--violet);
+}
+
+.logo:hover {
+  text-decoration: none;
+}
+
+.logo svg:hover {
+  fill: var(--link-hover-color);
+}
+
+.pkg-full-name {
+  display: flex;
+  align-items: center;
+  font-size: var(--font-xl);
+  margin: 0 8px;
+  font-weight: var(--weight-normal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Entry signature styling - not a heading element */
+.entry-signature {
+  font-family: var(--font-mono);
+  background-color: var(--violet-bg);
+  color: var(--text-color);
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  border-left: 4px solid var(--violet);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: pre-wrap;
+  position: relative;
+  overflow: visible;
+}
+
+
+.entry-signature-code {
+  background: none;
+  font-size: inherit;
+  flex: 1;
+}
+
+.sig-arrow {
+  white-space: nowrap;
+}
+
+/* Type definition block shown below heading for nominal types (e.g. Try := ...) */
+.entry-type-def {
+  display: block;
+  font-family: var(--font-mono);
+  background-color: var(--violet-bg);
+  color: var(--text-color);
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  white-space: pre-wrap;
+  font-size: var(--font-base);
+  line-height: 1.5;
+}
+
+/* Match the entry-anchor-offset left margin applied to entry headings (.entry h2-h6) so the
+   type definition aligns with the heading name above it. */
+.entry > .entry-type-def {
+  margin-left: var(--entry-anchor-offset);
+}
+
+.entry-signature-code strong {
+    color: var(--text-color);
+    font-weight: var(--weight-semibold);
+}
+
+.entry-anchor {
+  visibility: hidden;
+  color: var(--violet);
+  text-decoration: none;
+  user-select: none;
+  transition: visibility 6s;
+  position: absolute;
+  left: calc(-1 * var(--entry-anchor-offset));
+  display: flex;
+  align-items: center;
+  height: 100%;
+  top: 0;
+}
+
+.entry-anchor .link-icon {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+  vertical-align: middle;
+}
+
+.entry h2,
+.entry h3,
+.entry h4,
+.entry h5,
+.entry h6 {
+  margin-left: var(--entry-anchor-offset);
+  position: relative;
+}
+
+.entry-signature:hover .entry-anchor,
+.entry h2:hover .entry-anchor,
+.entry h3:hover .entry-anchor,
+.entry h4:hover .entry-anchor,
+.entry h5:hover .entry-anchor,
+.entry h6:hover .entry-anchor {
+  visibility: visible;
+}
+
+.entry-name-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+
+.entry-group-header {
+    color: var(--violet);
+    padding: 8px 0;
+    margin-top: 0;
+}
+
+/* Hierarchical entry layout */
+.entry {
+    position: relative;
+    margin-bottom: 24px;
+}
+
+/* Targets of anchor-link navigation (permalink clicks, # references). */
+.entry[id],
+.entry-group[id] {
+  /* Offset so the target lands below the sticky search bar. */
+  scroll-margin-top: var(--module-search-form-height);
+}
+
+.entry-children-container {
+    margin-top: 16px;
+    margin-left: var(--entry-anchor-offset);
+}
+
+.entry-doc {
+    padding-left: 20px;
+}
+
+/* Entry type vs value styling */
+.entry-type > .entry-signature {
+    font-weight: var(--weight-semibold);
+    background-color: var(--violet-bg);
+    border-left: 4px solid var(--violet);
+    font-size: var(--font-base);
+    line-height: 1.5;
+}
+
+.entry-value > .entry-signature {
+    font-weight: var(--weight-normal);
+    background-color: transparent;
+    border-left: 4px solid rgb(from var(--violet) r g b);
+    font-size: var(--font-base);
+    line-height: 1.5;
+}
+
+
+.pkg-full-name a {
+  padding-top: 12px;
+  padding-bottom: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+a {
+  text-decoration: none;
+}
+
+a:hover,
+a:hover code {
+  text-decoration: underline;
+  text-decoration-thickness: 3px;
+  text-underline-offset: 5px;
+}
+
+.pkg-and-logo {
+  min-width: 0; /* necessary for text-overflow: ellipsis to work in descendants */
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  background-color: var(--violet-bg);
+  padding: 16px;
+}
+
+.pkg-and-logo a,
+.pkg-and-logo a:visited {
+  color: var(--violet);
+}
+
+.pkg-and-logo a:hover {
+  color: var(--link-hover-color);
+  text-decoration: none;
+}
+
+body {
+  display: grid;
+  grid-template-columns:
+      [sidebar] var(--sidebar-width)
+      [main-content] 1fr
+      [content-end];
+  grid-template-rows: 1fr;
+  height: 100dvh;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-sans);
+  font-size: var(--font-sm);
+  line-height: 1.6;
+  color: var(--text-color);
+  background-color: var(--body-bg-color);
+  overflow: hidden;
+}
+
+main {
+  grid-column-start: main-content;
+  grid-column-end: content-end;
+  box-sizing: border-box;
+  position: relative;
+  font-size: var(--font-base);
+  line-height: 1.6;
+  margin-top: 2px;
+  padding: 16px;
+  padding-top: 0px;
+  /* necessary for text-overflow: ellipsis to work in descendants */
+  min-width: 0;
+  overflow-x: auto;
+  /* fixes issues with horizontal scroll in cases where word is too long,
+  like in one of the examples at https://www.roc-lang.org/builtins/Num#Dec */
+  overflow-y: auto;
+  display: grid;
+  --main-content-width: clamp(100px, calc(100% - 32px), 70ch);
+  grid-template-columns: [main-start] minmax(16px,1fr) [main-content-start] var(--main-content-width) [main-content-end] minmax(16px,1fr) [main-end];
+  grid-template-rows: auto 1fr auto;
+  scrollbar-color: var(--violet) var(--body-bg-color);
+  scrollbar-gutter: stable both-edges;
+}
+
+main > * {
+    grid-column-start: main-content-start;
+    grid-column-end: main-content-end;
+}
+
+.main-content {
+    min-width: 0;
+}
+
+/* Module links on the package index page (/index.html) */
+.index-module-links {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+    font-size: large;
+}
+
+section:not(.langref-article) {
+  padding: 0px 0px 16px 20px;
+}
+
+section blockquote {
+  font-style: italic;
+  position: relative;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+section blockquote:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 2px;
+  height: 100%;
+  background-color: var(--gray);
+}
+
+
+section > *:last-child {
+  margin-bottom: 0;
+}
+
+section:not(.langref-article) h1,
+section:not(.langref-article) h2,
+section:not(.langref-article) h3,
+section:not(.langref-article) h4,
+section:not(.langref-article) p {
+padding: 0px 16px;
+}
+
+/* Language reference articles reuse the module-page chrome and layout. These
+   rules give the converted Markdown block elements (lists, tables, code blocks)
+   their horizontal rhythm. Headings and the page title use the page font rather
+   than the monospace reserved for code identifiers. */
+.module-name.langref-title,
+.langref-article h1,
+.langref-article h2,
+.langref-article h3,
+.langref-article h4,
+.langref-article h5,
+.langref-article h6 {
+  font-family: var(--font-sans);
+}
+
+.langref-article ul,
+.langref-article ol {
+  margin: 12px 0;
+  padding-left: 40px;
+}
+
+.langref-article li {
+  margin: 4px 0;
+}
+
+.langref-article li > ul,
+.langref-article li > ol {
+  margin: 4px 0;
+}
+
+.langref-article pre {
+  margin-left: 16px;
+  margin-right: 16px;
+}
+
+.langref-article table {
+  border-collapse: collapse;
+  margin: 16px;
+}
+
+#sidebar-nav {
+    grid-column-start: sidebar;
+    grid-column-end: main-content;
+    position: relative;
+    display: grid;
+    grid-template-rows: min-content 1fr;
+    box-sizing: border-box;
+    width: 100%;
+    background-color: var(--sidebar-bg-color);
+    transition: all 1s linear;
+}
+
+#sidebar-nav .module-links-container {
+    position: relative;
+}
+
+
+#sidebar-nav .module-links {
+    position: absolute;
+    inset: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-color: var(--violet) var(--sidebar-bg-color);
+    scrollbar-gutter: stable;
+    padding: 16px 8px;
+    transition: all .2s linear;
+    list-style: none;
+}
+
+p {
+  overflow-wrap: break-word;
+  margin: 24px 0;
+}
+
+footer {
+  font-size: var(--font-sm);
+  box-sizing: border-box;
+  padding: 16px 0px 0px;
+}
+
+footer p {
+  display: inline-block;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.sidebar-entry ul {
+  list-style-type: none;
+  margin: 0;
+}
+
+.sidebar-entry a {
+  box-sizing: border-box;
+  min-height: 40px;
+  min-width: 48px;
+  padding-left: 16px;
+  font-family: var(--font-mono);
+}
+
+.sidebar-entry a,
+.sidebar-entry a:visited {
+  color: var(--text-color);
+}
+
+.sidebar-sub-entries {
+    font-size: var(--font-sm);
+    display: none;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.active + .sidebar-sub-entries {
+    display: block;
+}
+
+/* When a module entry is itself nested inside another entry's sub-entry list
+   (e.g. the builtin type modules under "Builtin Types"), indent its members so
+   they sit underneath their type rather than level with it. Top-level modules
+   and types are not descendants of a sub-entry list, so they are unaffected. */
+.sidebar-sub-entries .sidebar-entry > .sidebar-sub-entries {
+    margin-left: 22px;
+}
+
+.sidebar-sub-entries a {
+  display: flex;
+  align-items: center;
+  line-height: 24px;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-left: 20px;
+  padding-left: 16px;
+  /* Transparent by default so the indent is consistent; only values/methods
+     (`.sidebar-value`) get a visible bar — nested types, type-module entries,
+     and language-reference links do not. */
+  border-left: 4px solid transparent;
+  white-space: nowrap;
+}
+
+.sidebar-sub-entries a.sidebar-value {
+  border-left-color: var(--gray-border-subtle);
+  padding-left: 20px;
+}
+
+.sidebar-sub-entries > li:first-child > a {
+    margin-top: 8px;
+    padding-top: 0;
+}
+
+.sidebar-sub-entries > li:last-child > a {
+    margin-bottom: 8px;
+    padding-bottom: 0;
+}
+
+.sidebar-sub-entries a:hover {
+    color: var(--violet);
+    text-decoration: none;
+}
+
+.sidebar-sub-entries a.sidebar-value:hover {
+    border-left-color: var(--violet-border-hover);
+}
+
+/* Builtin docs only (the langref-enabled site): the "Builtin Types" and
+   "Language Reference" sidebar entries, and the langref article links, are
+   prose labels rather than code identifiers, so they use the page font instead
+   of the monospace used elsewhere in the sidebar. Inline `code` inside a
+   langref article link keeps its monospace styling via the `code` rule. */
+.pkg-full-name.prose-label,
+.sidebar-module-link.prose-label,
+.langref-articles a {
+  font-family: var(--font-sans);
+}
+
+.sidebar-type {
+    margin-left: 0;
+}
+
+.sidebar-type-name {
+    font-weight: var(--weight-medium);
+    font-size: var(--font-base);
+    cursor: pointer;
+    text-decoration: none;
+    color: inherit;
+    display: inline-block;
+    padding-left: 16px;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    box-sizing: border-box;
+}
+
+.sidebar-type-name:hover {
+    color: var(--violet);
+}
+
+.sidebar-type > .sidebar-sub-entries {
+    max-height: 0;
+    overflow: hidden;
+    margin-left: 0;
+    transition: max-height 200ms ease-out;
+}
+
+.sidebar-type.expanded > .sidebar-sub-entries {
+    max-height: 10000px;
+    transition: max-height 200ms ease-in;
+}
+
+.module-name {
+  font-size: var(--font-2xl);
+  line-height: 1.2;
+  font-family: var(--font-mono);
+  font-weight: var(--weight-bold);
+  margin-top: 36px;
+  color: var(--violet);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-mono);
+}
+
+h1 {
+  margin-bottom: 30px;
+}
+
+h2 {
+  font-size: var(--font-xl);
+  margin-bottom: 0;
+}
+
+h3 {
+  font-size: var(--font-lg);
+  margin-bottom: 0;
+}
+
+h4 {
+  font-size: var(--font-base);
+  margin-bottom: 0;
+  margin-top: 23px;
+}
+
+h5 {
+  font-size: var(--font-base);
+  margin-bottom: 0;
+  margin-top: 23px;
+}
+
+h6 {
+  font-size: var(--font-base);
+  margin-bottom: 0;
+  margin-top: 23px;
+}
+
+.module-name a,
+.module-name a:visited {
+color: inherit;
+}
+
+.module-name a:hover {
+  color: var(--link-hover-color);
+}
+
+a.sidebar-module-link {
+  box-sizing: border-box;
+  font-size: var(--font-base);
+  line-height: 1.5;
+  font-family: var(--font-mono);
+  font-weight: var(--weight-normal);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-module-link:hover {
+    text-decoration: none;
+
+    span:hover {
+        color: var(--violet);
+    }
+}
+
+.sidebar-module-link span {
+    display: inline-block;
+    flex-grow: 1;
+}
+
+.sidebar-module-link.active {
+  font-weight: var(--weight-bold);
+}
+
+.sidebar-module-link > .entry-toggle {
+    background-color: transparent;
+    appearance: none;
+    border: none;
+    color: transparent;
+    color: rgba(from var(--text-color) r g b / .5);
+    transition: all 80ms linear;
+    text-decoration: none;
+    font-size: 0.8rem;
+    cursor: pointer;
+    padding: 8px 16px;
+
+    &:hover {
+        color: var(--violet);
+    }
+}
+
+/* The triangle itself: a single SVG (`--toggle-triangle`) masked by the toggle's
+   current color, so it tracks the gray/hover-violet transitions. */
+.entry-toggle::before {
+    content: "";
+    display: inline-block;
+    width: 0.85rem;
+    height: 0.85rem;
+    vertical-align: middle;
+    background-color: currentColor;
+    -webkit-mask: var(--toggle-triangle) center / contain no-repeat;
+    mask: var(--toggle-triangle) center / contain no-repeat;
+}
+
+.sidebar-entry:hover > a > .entry-toggle,
+.sidebar-module-link:hover > .entry-toggle {
+    color: var(--text-color);
+}
+
+/* Nested module toggles (e.g. the builtin types under "Builtin Types") sit in a
+   smaller-font line and read a touch low; nudge them up to center on the label.
+   `top` offsets the box before the `rotate` spins it, so both states stay aligned. */
+.sidebar-sub-entries .entry-toggle {
+    position: relative;
+    top: -2px;
+}
+
+.active .entry-toggle {
+    rotate: 90deg;
+}
+
+a,
+a:visited {
+  color: var(--link-color);
+}
+
+
+code {
+  font-family: var(--font-mono);
+  color: var(--code-color);
+  background-color: var(--code-bg);
+  display: inline-block;
+}
+
+p code {
+  padding: 0 4px;
+}
+
+/* Inline code in headings should blend in with the heading, not look like a
+   highlighted code chip. */
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
+  background-color: transparent;
+  padding: 0;
+}
+
+code a,
+a code {
+  text-decoration: none;
+  color: var(--code-link-color);
+  background: none;
+  padding: 0;
+  font-weight: bold; /* Important for AAA compliance while keeping color distinct */
+}
+
+code a .type,
+code a:hover .type,
+code a:visited .type {
+  color: var(--green) !important;
+}
+
+code a:visited,
+a:visited code {
+  color: var(--code-link-color);
+}
+
+pre {
+  margin: 36px 0;
+  padding: 8px 16px;
+  box-sizing: border-box;
+  background-color: var(--code-bg);
+  position: relative;
+  word-wrap: normal;
+}
+
+pre>code {
+    overflow-x: auto;
+    display: block;
+    scrollbar-color: var(--violet) var(--code-bg);
+    scrollbar-width: thin;
+    scrollbar-gutter: stable;
+}
+
+.hidden {
+  /* Use !important to win all specificity fights. */
+  display: none !important;
+}
+
+#module-search-form {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: sticky;
+  box-sizing: border-box;
+  padding: 12px 0;
+  background-color: var(--body-bg-color);
+  top: 0;
+  z-index: 1;
+  margin-bottom: 8px;
+}
+
+
+.menu-toggle {
+    display: none;
+    margin-right: 8px;
+    appearance: none;
+    background-color: transparent;
+    outline: none;
+    border: none;
+    color: var(--violet);
+    padding: 0;
+    cursor: pointer;
+}
+
+.menu-toggle svg {
+    height: var(--icon-size);
+    width: var(--icon-size);
+    fill: var(--violet);
+}
+
+
+#module-search,
+#module-search-nojs,
+#module-search:focus {
+  opacity: 1;
+  padding: 12px 16px;
+  height: var(--module-search-height);
+}
+
+#module-search,
+#module-search-nojs {
+  display: block;
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  font-size: var(--font-base);
+  line-height: 18px;
+  color: var(--text-color);
+  background-color: var(--body-bg-color);
+  font-family: var(--font-sans);
+  border: 2px solid var(--search-border-color);
+}
+
+/* Hidden when JS is enabled. The <noscript><style> in #module-search-form
+   re-enables it (and hides #module-search) when JS is disabled. */
+#module-search-nojs {
+  display: none;
+}
+
+#module-search::placeholder,
+#module-search-nojs::placeholder {
+  color: var(--faded-color);
+  opacity: 1;
+}
+
+#module-search:focus, #module-search:hover {
+  outline: 2px solid var(--violet);
+}
+
+#search-type-ahead {
+  font-family: var(--font-mono);
+  display: flex;
+  gap: 0px;
+  flex-direction: column;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  box-sizing: border-box;
+  z-index: 100;
+  background-color: var(--body-bg-color);
+  border: 2px solid var(--violet);
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+#search-type-ahead .type-ahead-link {
+  font-size: var(--font-base);
+  color: var(--text-color);
+  line-height: 2em;
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 4px 8px;
+
+  display: block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+
+  span {
+    margin: 0px;
+  }
+
+  .type-ahead-module-name, .type-ahead-def-name {
+    color: var(--violet);
+    font-size: var(--font-base);
+  }
+}
+
+#search-type-ahead li {
+  box-sizing: border-box;
+  position: relative;
+}
+
+#search-type-ahead a:focus {
+  outline: none;
+  background: var(--violet-bg);
+}
+
+
+@media (prefers-color-scheme: dark) {
+  :root {
+      /* WCAG AAA Compliant colors */
+    --code-bg: hsl(228.95deg 37.25% 15%);
+    --gray: hsl(0 0% 70% / 1);
+    --orange: hsl(25 98% 70% / 1);
+    --green: hsl(115 40% 70% / 1);
+    --cyan: hsl(176 84% 70% / 1);
+    --blue: hsl(243 43% 80% / 1);
+    --violet: #caadfb;
+    --violet-bg: hsl(262 25% 15% / 1);
+    --magenta: hsl(348 79% 80% / 1);
+      --link-hover-color: #fff;
+
+      --link-color: var(--violet);
+      --code-link-color: var(--violet);
+      --text-color: #eaeaea;
+      --body-bg-color: hsl(from var(--violet-bg) h s calc(l * .5));
+      --border-color: var(--gray);
+      --code-color: #eeeeee;
+      --logo-solid: #8f8f8f;
+      --faded-color: #bbbbbb;
+      --sidebar-bg-color: hsl(from var(--violet-bg) h calc(s * 1.1) calc(l * 0.75));
+      --search-border-color: hsl(262 35% 40%);
+  }
+
+  html {
+      scrollbar-color: #8f8f8f #2f2f2f;
+  }
+
+  /* In dark mode "lighter" means more of the near-white text color, i.e. a
+     higher alpha (the opposite of light mode, where lighter means fading toward
+     the light background). */
+  .sidebar-module-link > .entry-toggle {
+      color: rgba(from var(--text-color) r g b / .8);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+    :root {
+        --sidebar-width: clamp(280px, 50dvw, 385px);
+    }
+    body {
+        display: block;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    html {
+        scroll-padding-top: var(--module-search-form-height);
+    }
+
+    #sidebar-nav {
+        left: calc(-1 * var(--sidebar-width));
+        top: 0;
+        bottom: 0;
+        position: fixed;
+        z-index: 2;
+        transition: all .2s linear;
+    }
+
+    .entry-toggle {
+        height: var(--icon-size);
+        width: var(--icon-size);
+    }
+
+    body.sidebar-open #sidebar-nav {
+        left: 0;
+    }
+
+    main {
+        display: flex;
+        flex-direction: column;
+        margin: 0;
+        min-height: 100dvh;
+        --main-content-width: minmax(calc(100% - 32px), 60ch);
+    }
+
+    main > .main-content {
+        flex: 1;
+    }
+
+    #module-search-form {
+        padding: 16px 16px;
+        height: auto;
+        margin-bottom: 16px;
+        grid-column-start: main-content-start;
+        grid-column-end: main-content-end;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        justify-content: flex-start;
+    }
+
+    #module-search-form:has(#module-search:focus) .menu-toggle {
+        max-width: 0;
+        margin-left: 0;
+        opacity: 0;
+    }
+
+    .entry-anchor {
+        display: none;
+    }
+
+    .entry-signature {
+        padding-left: 8px;
+        padding-right: 8px;
+    }
+
+    .menu-toggle {
+        display: block;
+        flex-shrink: 0;
+        max-width: var(--icon-size);
+        overflow: hidden;
+        margin-left: 16px;
+        appearance: none;
+        background-color: transparent;
+        outline: none;
+        border: none;
+        color: var(--violet);
+        padding: 0;
+        cursor: pointer;
+        touch-action: manipulation;
+        transition: max-width 0.2s ease, margin-left 0.2s ease, opacity 0.2s ease;
+    }
+
+    #module-search,
+    #module-search-nojs {
+        flex: 1;
+        width: auto;
+    }
+
+    .pkg-full-name {
+        font-size: 20px;
+        padding-bottom: 14px;
+    }
+
+    .pkg-full-name a {
+        vertical-align: middle;
+        padding: 18px 0;
+    }
+
+    .logo {
+        width: 50px;
+        height: 54px;
+    }
+
+    .module-name {
+        font-size: var(--font-2xl);
+        margin-top: 8px;
+        margin-bottom: 8px;
+        /* Align with the left border of #module-search-form's input.
+           main now has no margin and padding-left: 18px, so content starts at x=18;
+           the fixed search form's input border sits at x=16 (form padding-left). */
+        margin-left: -2px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    /* Reduce section's desktop 20px left padding on mobile. */
+    section {
+        padding-left: 7px;
+    }
+
+    /* Reduce var(--entry-anchor-offset) left margins that reserve space for .entry-anchor
+       (which is hidden on mobile). Applies to entry headings, the type-def
+       block aligned with them, and the children container nested below. */
+    .entry h2,
+    .entry h3,
+    .entry h4,
+    .entry h5,
+    .entry h6,
+    .entry > .entry-type-def,
+    .entry-children-container {
+        margin-left: 8px;
+    }
+
+    /* Full-bleed code blocks */
+    pre {
+        margin-left: -24px;
+        margin-right: -24px;
+    }
+
+    main {
+        padding: 18px;
+        font-size: var(--font-base);
+        padding-top: var(--module-search-form-height);
+    }
+
+    #sidebar-nav {
+        margin-top: 0;
+        padding-left: 0;
+        width: var(--sidebar-width);
+    }
+
+    h3 {
+        font-size: 18px;
+        margin: 0;
+        padding: 0;
+    }
+
+    h4 {
+        font-size: var(--font-base);
+    }
+
+    body {
+        margin: 0;
+        min-width: 320px;
+        max-width: 100dvw;
+    }
+
+    .pkg-and-logo {
+        padding-block: 4px;
+    }
+
+    .pkg-full-name {
+        flex-grow: 1;
+    }
+
+    .pkg-full-name a {
+        padding-top: 24px;
+        padding-bottom: 12px;
+    }
+}
+
+/* Comments `#` and Documentation comments `##` */
+samp .comment,
+code .comment {
+  color: var(--green);
+}
+
+/* Number, String, Tag literals */
+samp .storage.type,
+code .storage.type,
+samp .string,
+code .string,
+samp .string.begin,
+code .string.begin,
+samp .string.end,
+code .string.end,
+samp .constant,
+code .constant,
+samp .literal,
+code .literal {
+  color: var(--cyan);
+}
+
+/* Keywords and punctuation */
+samp .keyword,
+code .keyword,
+samp .punctuation.section,
+code .punctuation.section,
+samp .punctuation.separator,
+code .punctuation.separator,
+samp .punctuation.terminator,
+code .punctuation.terminator,
+samp .kw,
+code .kw {
+    color: var(--magenta);
+}
+
+/* Operators */
+samp .op,
+code .op,
+samp .keyword.operator,
+code .keyword.operator {
+  color: var(--orange);
+}
+
+/* Delimieters */
+samp .delimiter,
+code .delimiter {
+  color: var(--gray);
+}
+
+/* Variables modules and field names */
+samp .function,
+code .function,
+samp .meta.group,
+code .meta.group,
+samp .meta.block,
+code .meta.block,
+samp .lowerident,
+code .lowerident {
+  color: var(--blue);
+}
+
+/* Types, Tags, and Modules */
+samp .type,
+code .type,
+samp .meta.path,
+code .meta.path,
+samp .upperident,
+code .upperident {
+  color: var(--green);
+}
+
+samp .dim,
+code .dim {
+  opacity: 0.55;
+}
+
+.button-container {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.copy-button {
+  background: var(--code-bg);
+  border: 1px solid var(--magenta);
+  color: var(--magenta);
+  display: inline-block;
+  cursor: pointer;
+  margin: 8px;
+}
+
+.copy-button:hover {
+  border-color: var(--link-hover-color);
+  color: var(--link-hover-color);
+}
+
+/* Search container and input styling */

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Redirecting...</title>
+        <script>
+            window.location.href = "/roc-parser/0.11.0/";
+        </script>
+    </head>
+    <body>
+        <noscript>
+            <p>
+                If you are not automatically redirected, please
+                <a href="/roc-parser/0.11.0/">click here</a>.
+            </p>
+        </noscript>
+    </body>
+</html>


### PR DESCRIPTION
Follow-up for release 0.11.0.\n\nChanges:\n- update examples to use the 0.11.0 package bundle URL\n- generate fresh docs under www/0.11.0\n- update www/index.html to redirect to 0.11.0\n- restore a GitHub Pages deploy workflow for www/ so merging docs changes publishes the site