### PR TITLE
Update examples for platform template 1.0.0

### DIFF
--- a/examples/csv-movies.roc
+++ b/examples/csv-movies.roc
@@ -1,6 +1,6 @@
 app [main!] {
-    cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-    parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
+	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
+	parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
 }
 
 import parser.Parser
@@ -10,72 +10,86 @@ import cli.Stdout
 import cli.Stderr
 
 input : Str
-input =
-    \\Airplane!,1980,\"Robert Hays,Julie Hagerty\"
-    \\Caddyshack,1980,\"Chevy Chase,Rodney Dangerfield,Ted Knight,Michael O'Keefe,Bill Murray\"
+input = 
+	\\Airplane!,1980,\"Robert Hays,Julie Hagerty\"
+	\\Caddyshack,1980,\"Chevy Chase,Rodney Dangerfield,Ted Knight,Michael O'Keefe,Bill Murray\"
 
+MovieInfo : { title : Str, release_year : U64, actors : List(Str) }
+
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), StderrErr(Str), ..])
 main! = |_args| {
-    match CSV.parse_str(movie_info_parser, input) {
-        Ok(movies) => {
-            movies_string =
-                movies
-                .map(movie_info_explanation)
-                ->Str.join_with("\n")
+	match CSV.parse_str(movie_info_parser, input) {
+		Ok(movies) => {
+			movies_string = 
+				movies
+					.map(movie_info_explanation)
+					->Str.join_with("\n")
 
-            n_movies = movies.len().to_str()
+			n_movies = movies.len().to_str()
 
-            Stdout.line!("${n_movies} movies were found:\n\n${movies_string}\n\nParse success!\n")
-        }
+			Stdout.line!("${n_movies} movies were found:\n\n${movies_string}\n\nParse success!\n")?
+		}
 
-        Err(problem) => {
-            match problem {
-                ParsingFailure(failure) => {
-                    Stderr.line!("Parsing failure: ${failure}\n")
-                }
+		Err(problem) => {
+			match problem {
+				ParsingFailure(failure) => {
+					Stderr.line!("Parsing failure: ${failure}\n")?
+				}
 
-                ParsingIncomplete(leftover) => {
-                    leftover_str =
-                        leftover
-                        .map(String.str_from_utf8)
-                        .map(|val| "\"${val}\"")
-                        ->Str.join_with(", ")
+				ParsingIncomplete(leftover) => {
+					leftover_str = 
+						leftover
+							.map(String.str_from_utf8)
+							.map(|val| "\"${val}\"")
+							->Str.join_with(", ")
 
-                    Stderr.line!("Parsing incomplete. Following leftover fields while parsing a record: ${leftover_str}\n")
-                }
+					Stderr.line!("Parsing incomplete. Following leftover fields while parsing a record: ${leftover_str}\n")?
+				}
 
-                SyntaxError(error) => {
-                    Stderr.line!("Parsing failure. Syntax error in the CSV: ${error}")
-                }
-            }
-        }
-    }
+				SyntaxError(error) => {
+					Stderr.line!("Parsing failure. Syntax error in the CSV: ${error}")?
+				}
+			}
+		}
+	}
 
-    Ok({})
+	Ok({})
 }
 
-movie_info_parser =
-    CSV.record(|title| |release_year| |actors| { { title, release_year, actors } })
-    .keep(CSV.field(CSV.string))
-    .keep(CSV.field(CSV.u64))
-    .keep(CSV.field(actors_parser))
+movie_info_parser : Parser(CSV.CSVRecord, MovieInfo)
+movie_info_parser = 
+	CSV.record(
+		|title| |release_year| |actors| {
+			{ title, release_year, actors }
+		},
+	)
+		.keep(CSV.field(CSV.string))
+		.keep(CSV.field(CSV.u64))
+		.keep(CSV.field(actors_parser))
 
-actors_parser = (CSV.string).map(|val| { val.split_on(",") })
+actors_parser : Parser(CSV.CSVField, List(Str))
+actors_parser = (CSV.string).map(
+	|val| {
+		val.split_on(",")
+	},
+)
 
+movie_info_explanation : MovieInfo -> Str
 movie_info_explanation = |{ title, release_year, actors }| {
-    enumerated_actors = enumerate(actors)
-    release_year_str = release_year.to_str()
+	enumerated_actors = enumerate(actors)
+	release_year_str = release_year.to_str()
 
-    "The movie '${title}' was released in ${release_year_str} and stars ${enumerated_actors}"
+	"The movie '${title}' was released in ${release_year_str} and stars ${enumerated_actors}"
 }
 
 enumerate : List(Str) -> Str
 enumerate = |elements| {
-    match elements {
-        [] => ""
-        [actor] => actor
-        [.. as inits, last] => 
-            [last]
-            .prepend(inits->Str.join_with(", "))
-            ->Str.join_with(" and ")
-    }
+	match elements {
+		[] => ""
+		[actor] => actor
+		[.. as inits, last] =>
+			[last]
+				.prepend(inits->Str.join_with(", "))
+				->Str.join_with(" and ")
+		}
 }

--- a/examples/letters.roc
+++ b/examples/letters.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
 }
 
@@ -8,13 +8,14 @@ import cli.Stderr
 import parser.Parser
 import parser.String
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), StderrErr(Str), ..])
 main! = |_args| {
 	result : Try(List(Letter), [ParsingFailure(Str), ParsingIncomplete(Str)])
 	result = String.parse_str(letter_parser.many(), "AAAiBByAABBwBtCCCiAyArBBx")
 
 	match result.map_ok(count_letter_as) {
-		Ok(count) => Stdout.line!("I counted ${count.to_str()} letter A's!")
-		Err(_) => Stderr.line!("Failed while parsing input")
+		Ok(count) => Stdout.line!("I counted ${count.to_str()} letter A's!")?
+		Err(_) => Stderr.line!("Failed while parsing input")?
 	}
 	Ok({})
 }
@@ -22,6 +23,7 @@ main! = |_args| {
 Letter : [A, B, C, Other]
 
 # Helper to check if a letter is an A tag
+is_a : Letter -> Bool
 is_a = |l| l == A
 
 # Count the number of Letter A's
@@ -52,17 +54,19 @@ letter_parser = Parser.build_primitive_parser(
 )
 
 # Test we can parse a single B letter
+## A single B byte parses as the B tag.
 expect {
 	input = "B"
 	parser = letter_parser
-	result = parser->String.parse_str(input)
-	result == Ok(B)
+	result = parser->String.parse_str(input)?
+	result == B
 }
 
 # Test we can parse a number of different letters
+## Multiple bytes parse into their corresponding letter tags.
 expect {
 	input = "BCXA"
 	parser = letter_parser.many()
-	result = parser->String.parse_str(input)
-	result == Ok([B, C, Other, A])
+	result = parser->String.parse_str(input)?
+	result == [B, C, Other, A]
 }

--- a/examples/markdown.roc
+++ b/examples/markdown.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
 }
 
@@ -22,6 +22,7 @@ content =
 	\\foo = bar
 	\\```
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
 	parsed = 
 		String.parse_str(Markdown.all, content)
@@ -32,7 +33,7 @@ main! = |_args| {
 			)
 			?? "PARSING ERROR"
 
-	Stdout.line!(parsed)
+	Stdout.line!(parsed)?
 	Ok({})
 }
 

--- a/examples/numbers.roc
+++ b/examples/numbers.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
 }
 
@@ -8,13 +8,14 @@ import cli.Stderr
 import parser.Parser
 import parser.String
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), StderrErr(Str), ..])
 main! = |_args| {
 	result : Try(List(List(U64)), [ParsingFailure(Str), ParsingIncomplete(Str)])
 	result = String.parse_str(multiple_numbers.many(), "1000\n2000\n3000\n\n4000\n\n5000\n6000\n\n")
 
 	match result.map_ok(largest) {
-		Ok(count) => Stdout.line!("The largest sum is ${count.to_str()}")
-		Err(_) => Stderr.line!("Failed while parsing input")
+		Ok(count) => Stdout.line!("The largest sum is ${count.to_str()}")?
+		Err(_) => Stderr.line!("Failed while parsing input")?
 	}
 	Ok({})
 }
@@ -26,9 +27,10 @@ single_number =
 		.keep(String.digits)
 		.skip(String.string("\n"))
 
+## A number parser consumes one newline-terminated number.
 expect {
-	actual = String.parse_str(single_number, "1000\n")
-	actual == Ok(1000)
+	actual = String.parse_str(single_number, "1000\n")?
+	actual == 1000
 }
 
 # Parse a series of numbers followed by a newline
@@ -38,9 +40,10 @@ multiple_numbers =
 		.keep(single_number.many())
 		.skip(String.string("\n"))
 
+## A list parser consumes numbers until the blank line terminator.
 expect {
-	actual = String.parse_str(multiple_numbers, "1000\n2000\n3000\n\n")
-	actual == Ok([1000, 2000, 3000])
+	actual = String.parse_str(multiple_numbers, "1000\n2000\n3000\n\n")?
+	actual == [1000, 2000, 3000]
 }
 
 # Sum up the lists and return the largest sum
@@ -52,4 +55,5 @@ largest = |numbers|
 		.first()
 		?? 0
 
+## The largest grouped total is selected from the parsed numbers.
 expect largest([[1000, 2000, 3000], [4000], [5000, 6000]]) == 11_000

--- a/examples/xml-svg.roc
+++ b/examples/xml-svg.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	cli: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	# TODO: point to the migrated html library
 	html: "https://github.com/lukewilliamboswell/roc-html/...",
 	parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.11.0/HS5cXN8JrJKdxM2Y8azXzbHCxCx2qxocySTGr6sLGQTZ.tar.zst",
@@ -28,20 +28,28 @@ expected_html =
 	\\    ] []
 	\\]
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
-	svg_converted_to_html = 
+	result = 
 		String.parse_str(Xml.xml_parser, svg_input)
 			.map_ok(
 				|xml| {
 					html_to_roc_dsl(svg_to_html(xml.root), "", 0)
 				},
-			)?
+			)
 
-	if svg_converted_to_html == expected_html {
-		Stdout.line!("Successfully converted SVG into HTML DSL")
-	} else {
-		Stdout.line!("Did not match expected HTML DSL")
-	}
+	match result {
+		Ok(svg_converted_to_html) if svg_converted_to_html == expected_html =>
+			Stdout.line!("Successfully converted SVG into HTML DSL")?
+
+		Ok(_) =>
+			Stdout.line!("Did not match expected HTML DSL")?
+
+		Err(_) =>
+			Stdout.line!("Failed while parsing SVG")?
+		}
+
+	Ok({})
 }
 
 svg_to_html : Xml.Node -> Html.Node
@@ -98,11 +106,13 @@ html_to_roc_dsl = |html, buf, depth| {
 	}
 }
 
+## Text nodes render as text calls.
 expect {
 	a = html_to_roc_dsl(Html.text("foo"), "", 0)
 	a == "text \"foo\""
 }
 
+## Element attributes render in a bracketed attribute list.
 expect {
 	a = html_to_roc_dsl(Html.h1([Attribute.class("green"), Attribute.width("1rem")], [Html.text("foo")]), "", 0)
 	a
@@ -115,6 +125,7 @@ expect {
 		\\]
 }
 
+## Multiple text children render on separate lines.
 expect {
 	a = html_to_roc_dsl(Html.h1([], [Html.text("foo"), Html.text("bar"), Html.text("baz")]), "", 0)
 	a
@@ -126,6 +137,7 @@ expect {
 		\\]
 }
 
+## Nested elements increase the rendered indentation.
 expect {
 	a = html_to_roc_dsl(Html.h1([], [Html.h2([Attribute.class("green")], [Html.text("foo")]), Html.text("bar")]), "", 0)
 	a
@@ -140,6 +152,7 @@ expect {
 		\\]
 }
 
+depth_to_ident : U8 -> Str
 depth_to_ident = |depth| {
 	(0..<depth)
 		.map(
@@ -150,6 +163,11 @@ depth_to_ident = |depth| {
 		.join_with("")
 }
 
+## Zero nesting renders no indentation.
 expect depth_to_ident(0) == ""
+
+## One nesting level renders four spaces.
 expect depth_to_ident(1) == "    "
+
+## Two nesting levels render eight spaces.
 expect depth_to_ident(2) == "        "

--- a/package/HTTP.roc
+++ b/package/HTTP.roc
@@ -127,8 +127,17 @@ method =
 		],
 	)
 
-expect String.parse_str(method, "GET") == Ok(Get)
-expect String.parse_str(method, "DELETE") == Ok(Delete)
+## GET parses as the Get method tag.
+expect {
+	actual = String.parse_str(method, "GET")?
+	actual == Get
+}
+
+## DELETE parses as the Delete method tag.
+expect {
+	actual = String.parse_str(method, "DELETE")?
+	actual == Delete
+}
 
 # TODO: do we want more structure in the URI, or is Str actually what programs want anyway?
 # This is not a full URL!
@@ -163,9 +172,10 @@ http_version =
 		.skip(String.codeunit('.'))
 		.keep((String.digits).map(U64.to_u8_wrap)) # TODO: change to to_u8_try
 
+## HTTP version parsing captures the major and minor numbers.
 expect {
-	actual = String.parse_str(http_version, "HTTP/1.1")
-	expected = Ok({ major: 1, minor: 1 })
+	actual = String.parse_str(http_version, "HTTP/1.1")?
+	expected = { major: 1, minor: 1 }
 	actual == expected
 }
 
@@ -203,12 +213,14 @@ header =
 		.keep(string_without_cr)
 		.skip(crlf)
 
+## Header parsing splits the field name from its value.
 expect {
-	actual = String.parse_str(header, "Accept-Encoding: gzip, deflate\r\n")
-	expected = Ok(Header("Accept-Encoding", "gzip, deflate"))
+	actual = String.parse_str(header, "Accept-Encoding: gzip, deflate\r\n")?
+	expected = Header("Accept-Encoding", "gzip, deflate")
 	actual == expected
 }
 
+## HTTP request parsing captures method, URI, version, headers, and body.
 expect {
 	request_text = 
 		\\GET /things?id=1 HTTP/1.1\r
@@ -217,24 +229,23 @@ expect {
 		\\\r
 		\\Hello, world!
 	actual = 
-		String.parse_str(HTTP.request, request_text)
+		String.parse_str(HTTP.request, request_text)?
 
-	expected : Try(HTTP.Request, [ParsingFailure(Str), ParsingIncomplete(Str)])
-	expected = Ok(
-		{
-			method: Get,
-			uri: "/things?id=1",
-			http_version: { major: 1, minor: 1 },
-			headers: [
-				Header("Host", "bar.example"),
-				Header("Accept-Encoding", "gzip, deflate"),
-			],
-			body: "Hello, world!".to_utf8(),
-		},
-	)
+	expected : HTTP.Request
+	expected = {
+		method: Get,
+		uri: "/things?id=1",
+		http_version: { major: 1, minor: 1 },
+		headers: [
+			Header("Host", "bar.example"),
+			Header("Accept-Encoding", "gzip, deflate"),
+		],
+		body: "Hello, world!".to_utf8(),
+	}
 	actual == expected
 }
 
+## OPTIONS request parsing supports many headers and an empty body.
 expect {
 	request_text = 
 		\\OPTIONS /resources/post-here/ HTTP/1.1\r
@@ -248,28 +259,27 @@ expect {
 		\\Access-Control-Request-Headers: X-PINGOTHER, Content-Type\r
 		\\\r\n
 	actual = 
-		String.parse_str(HTTP.request, request_text)
-	expected = Ok(
-		{
-			method: Options,
-			uri: "/resources/post-here/",
-			http_version: { major: 1, minor: 1 },
-			headers: [
-				Header("Host", "bar.example"),
-				Header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
-				Header("Accept-Language", "en-us,en;q=0.5"),
-				Header("Accept-Encoding", "gzip,deflate"),
-				Header("Connection", "Parser.keep-alive"),
-				Header("Origin", "https://foo.example"),
-				Header("Access-Control-Request-Method", "POST"),
-				Header("Access-Control-Request-Headers", "X-PINGOTHER, Content-Type"),
-			],
-			body: [],
-		},
-	)
+		String.parse_str(HTTP.request, request_text)?
+	expected = {
+		method: Options,
+		uri: "/resources/post-here/",
+		http_version: { major: 1, minor: 1 },
+		headers: [
+			Header("Host", "bar.example"),
+			Header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
+			Header("Accept-Language", "en-us,en;q=0.5"),
+			Header("Accept-Encoding", "gzip,deflate"),
+			Header("Connection", "Parser.keep-alive"),
+			Header("Origin", "https://foo.example"),
+			Header("Access-Control-Request-Method", "POST"),
+			Header("Access-Control-Request-Headers", "X-PINGOTHER, Content-Type"),
+		],
+		body: [],
+	}
 	actual == expected
 }
 
+## HTTP response parsing captures headers and leaves the body bytes intact.
 expect {
 	body = 
 		\\<!DOCTYPE html>\r
@@ -302,31 +312,28 @@ expect {
 		\\\r
 		\\${body}
 	actual = 
-		String.parse_str(HTTP.response, response_text)
-	expected = 
-		Ok(
-			{
-				http_version: { major: 1, minor: 1 },
-				status_code: 200,
-				status: "OK",
-				headers: [
-					Header("Content-Type", "text/html; charset=utf-8"),
-					Header("Content-Length", "55743"),
-					Header("Connection", "Parser.keep-alive"),
-					Header("Cache-Control", "s-maxage=300, public, max-age=0"),
-					Header("Content-Language", "en-US"),
-					Header("Date", "Thu, 06 Dec 2018 17:37:18 GMT"),
-					Header("ETag", "\"2e77ad1dc6ab0b53a2996dfd4653c1c3\""),
-					Header("Server", "meinheld/0.6.1"),
-					Header("Strict-Transport-Security", "max-age=63072000"),
-					Header("X-Content-Type-Options", "nosniff"),
-					Header("X-Frame-Options", "DENY"),
-					Header("X-XSS-Protection", "1; mode=block"),
-					Header("Vary", "Accept-Encoding,Cookie"),
-					Header("Age", "7"),
-				],
-				body: body.to_utf8(),
-			},
-		)
+		String.parse_str(HTTP.response, response_text)?
+	expected = {
+		http_version: { major: 1, minor: 1 },
+		status_code: 200,
+		status: "OK",
+		headers: [
+			Header("Content-Type", "text/html; charset=utf-8"),
+			Header("Content-Length", "55743"),
+			Header("Connection", "Parser.keep-alive"),
+			Header("Cache-Control", "s-maxage=300, public, max-age=0"),
+			Header("Content-Language", "en-US"),
+			Header("Date", "Thu, 06 Dec 2018 17:37:18 GMT"),
+			Header("ETag", "\"2e77ad1dc6ab0b53a2996dfd4653c1c3\""),
+			Header("Server", "meinheld/0.6.1"),
+			Header("Strict-Transport-Security", "max-age=63072000"),
+			Header("X-Content-Type-Options", "nosniff"),
+			Header("X-Frame-Options", "DENY"),
+			Header("X-XSS-Protection", "1; mode=block"),
+			Header("Vary", "Accept-Encoding,Cookie"),
+			Header("Age", "7"),
+		],
+		body: body.to_utf8(),
+	}
 	actual == expected
 }

--- a/package/Markdown.roc
+++ b/package/Markdown.roc
@@ -147,14 +147,16 @@ todo =
 	Parser.const(|s| TODO(s))
 		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
 
+## Unsupported markdown lines are preserved as TODO nodes.
 expect {
-	a = String.parse_str(todo, "Foo Bar")
-	a == Ok(TODO("Foo Bar"))
+	a = String.parse_str(todo, "Foo Bar")?
+	a == TODO("Foo Bar")
 }
 
+## Multiple markdown lines parse into separate TODO nodes when unsupported.
 expect {
-	a = String.parse_str(Markdown.all, "Foo Bar\n\nBaz")
-	a == Ok([TODO("Foo Bar"), TODO(""), TODO("Baz")])
+	a = String.parse_str(Markdown.all, "Foo Bar\n\nBaz")?
+	a == [TODO("Foo Bar"), TODO(""), TODO("Baz")]
 }
 
 end_of_line = Parser.one_of([String.string("\n"), String.string("\r\n")])
@@ -163,8 +165,17 @@ not_end_of_line = |b| {
 	b != '\n' and b != '\r'
 }
 
-expect String.parse_str(Markdown.heading, "# Foo Bar") == Ok(Heading(One, "Foo Bar"))
-expect String.parse_str(Markdown.heading, "Foo Bar\n---") == Ok(Heading(Two, "Foo Bar"))
+## Hash-prefixed headings parse with their heading level.
+expect {
+	a = String.parse_str(Markdown.heading, "# Foo Bar")?
+	a == Heading(One, "Foo Bar")
+}
+
+## Underlined headings parse as level two headings.
+expect {
+	a = String.parse_str(Markdown.heading, "Foo Bar\n---")?
+	a == Heading(Two, "Foo Bar")
+}
 
 inline_heading = 
 	Parser.const(
@@ -188,14 +199,16 @@ inline_heading =
 		)
 		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
 
+## Inline headings capture the heading text after the marker.
 expect {
-	a = String.parse_str(inline_heading, "# Foo Bar")
-	a == Ok(Heading(One, "Foo Bar"))
+	a = String.parse_str(inline_heading, "# Foo Bar")?
+	a == Heading(One, "Foo Bar")
 }
 
+## Inline heading partial parsing leaves the following line untouched.
 expect {
-	a = String.parse_str_partial(inline_heading, "### Foo Bar\nBaz")
-	a == Ok({ val: Heading(Three, "Foo Bar"), input: "\nBaz" })
+	a = String.parse_str_partial(inline_heading, "### Foo Bar\nBaz")?
+	a == { val: Heading(Three, "Foo Bar"), input: "\nBaz" }
 }
 
 two_line_heading_level_one = 
@@ -215,14 +228,16 @@ two_line_heading_level_one =
 			),
 		)
 
+## Equal-sign underlines parse as level one headings.
 expect {
-	a = String.parse_str(two_line_heading_level_one, "Foo Bar\n==")
-	a == Ok(Heading(One, "Foo Bar"))
+	a = String.parse_str(two_line_heading_level_one, "Foo Bar\n==")?
+	a == Heading(One, "Foo Bar")
 }
 
+## Level one heading partial parsing leaves the trailing newline.
 expect {
-	a = String.parse_str_partial(two_line_heading_level_one, "Foo Bar\n=============\n")
-	a == Ok({ val: Heading(One, "Foo Bar"), input: "\n" })
+	a = String.parse_str_partial(two_line_heading_level_one, "Foo Bar\n=============\n")?
+	a == { val: Heading(One, "Foo Bar"), input: "\n" }
 }
 
 two_line_heading_level_two = 
@@ -242,31 +257,44 @@ two_line_heading_level_two =
 			),
 		)
 
+## Dash underlines parse as level two headings.
 expect {
-	a = String.parse_str(two_line_heading_level_two, "Foo Bar\n---")
-	a == Ok(Heading(Two, "Foo Bar"))
+	a = String.parse_str(two_line_heading_level_two, "Foo Bar\n---")?
+	a == Heading(Two, "Foo Bar")
 }
 
+## Level two heading partial parsing leaves the following line.
 expect {
-	a = String.parse_str_partial(two_line_heading_level_two, "Foo Bar\n-----\nApples")
-	a == Ok({ val: Heading(Two, "Foo Bar"), input: "\nApples" })
+	a = String.parse_str_partial(two_line_heading_level_two, "Foo Bar\n-----\nApples")?
+	a == { val: Heading(Two, "Foo Bar"), input: "\nApples" }
 }
 
-expect String.parse_str(Markdown.link, "[roc](https://roc-lang.org)") == Ok(Link({ alt: "roc", href: "https://roc-lang.org" }))
-
+## Markdown links capture their label and target URL.
 expect {
-	a = String.parse_str_partial(Markdown.link, "[roc](https://roc-lang.org)\nApples")
-	a == Ok({ val: Link({ alt: "roc", href: "https://roc-lang.org" }), input: "\nApples" })
+	a = String.parse_str(Markdown.link, "[roc](https://roc-lang.org)")?
+	a == Link({ alt: "roc", href: "https://roc-lang.org" })
 }
 
-expect String.parse_str(Markdown.image, "![alt text](/images/logo.png)") == Ok(Image({ alt: "alt text", href: "/images/logo.png" }))
-
+## Link partial parsing leaves the next line untouched.
 expect {
-	a = String.parse_str_partial(Markdown.image, "![alt text](/images/logo.png)\nApples")
-	a == Ok({ val: Image({ alt: "alt text", href: "/images/logo.png" }), input: "\nApples" })
+	a = String.parse_str_partial(Markdown.link, "[roc](https://roc-lang.org)\nApples")?
+	a == { val: Link({ alt: "roc", href: "https://roc-lang.org" }), input: "\nApples" }
+}
+
+## Markdown images capture their alt text and source URL.
+expect {
+	a = String.parse_str(Markdown.image, "![alt text](/images/logo.png)")?
+	a == Image({ alt: "alt text", href: "/images/logo.png" })
+}
+
+## Image partial parsing leaves the next line untouched.
+expect {
+	a = String.parse_str_partial(Markdown.image, "![alt text](/images/logo.png)\nApples")?
+	a == { val: Image({ alt: "alt text", href: "/images/logo.png" }), input: "\nApples" }
 }
 
 # TODO: fix the following expect
+## Code blocks capture their extension and body text.
 expect {
 	text = 
 		\\```roc
@@ -274,8 +302,8 @@ expect {
 		\\foo = bar
 		\\```
 
-	a = String.parse_str(Markdown.code, text)
-	a == Ok(Code({ ext: "roc", pre: "# some code\nfoo = bar\n" }))
+	a = String.parse_str(Markdown.code, text)?
+	a == Code({ ext: "roc", pre: "# some code\nfoo = bar\n" })
 }
 
 chomp_until_code_block_end : Parser(String.Utf8, Str)
@@ -296,10 +324,11 @@ chomp_to_code_block_end_help = |{ val, input }| {
 	}
 }
 
+## Chomping code block contents stops before the closing backticks.
 expect {
 	val = "".to_utf8()
 	input = "some code\n```".to_utf8()
 	expected = "some code\n".to_utf8()
-	a = chomp_to_code_block_end_help({ val, input })
-	a == Ok({ val: expected, input: [] })
+	a = chomp_to_code_block_end_help({ val, input })?
+	a == { val: expected, input: [] }
 }

--- a/package/Parser.roc
+++ b/package/Parser.roc
@@ -615,22 +615,25 @@ many_impl = |parser, vals, input| {
 		}
 }
 
+## Chomping until a newline returns the preceding bytes and leaves the newline.
 expect {
 	input = "# H\nR".to_utf8()
-	result = Parser.parse_partial(Parser.chomp_until('\n'), input)
-	result == Ok({ val: ['#', ' ', 'H'], input: ['\n', 'R'] })
+	result = Parser.parse_partial(Parser.chomp_until('\n'), input)?
+	result == { val: ['#', ' ', 'H'], input: ['\n', 'R'] }
 }
 
+## Chomping until a missing newline reports a parse error.
 expect {
 	Parser.parse_partial(Parser.chomp_until('\n'), []).is_err()
 }
 
+## Chomping while a predicate holds leaves the first non-matching byte.
 expect {
 	input : List(U8)
 	input = ['a', 's', '\n', 'd', 'f']
 	not_eol = |x| {
 		x != '\n'
 	}
-	result = Parser.parse_partial(Parser.chomp_while(not_eol), input)
-	result == Ok({ val: ['a', 's'], input: ['\n', 'd', 'f'] })
+	result = Parser.parse_partial(Parser.chomp_while(not_eol), input)?
+	result == { val: ['a', 's'], input: ['\n', 'd', 'f'] }
 }

--- a/package/String.roc
+++ b/package/String.roc
@@ -189,8 +189,18 @@ String :: {}.{
 			Bool.True
 		},
 	)
-	expect any_codeunit->parse_str("a") == Ok('a')
-	expect any_codeunit->parse_str("\$") == Ok(36)
+
+	## Any codeunit accepts a lowercase ASCII byte.
+	expect {
+		actual = any_codeunit->parse_str("a")?
+		actual == 'a'
+	}
+
+	## Any codeunit accepts a dollar-sign byte.
+	expect {
+		actual = any_codeunit->parse_str("\$")?
+		actual == 36
+	}
 
 	## Matches any `Utf8` and consumes all the input without fail.
 	## ```roc
@@ -205,9 +215,12 @@ String :: {}.{
 			Ok({ val: input, input: [] })
 		},
 	)
+
+	## Any input parser consumes all bytes.
 	expect {
 		bytes = "consumes all the input".to_utf8()
-		any_thing.parse(bytes, List.is_empty) == Ok(bytes)
+		actual = any_thing.parse(bytes, List.is_empty)?
+		actual == bytes
 	}
 
 	# Matches any string
@@ -330,18 +343,29 @@ str_from_codeunit = |cu| {
 	String.str_from_utf8([cu])
 }
 
-expect String.parse_str(String.any_codeunit, "a") == Ok('a')
-expect String.parse_str(String.any_codeunit, "\$") == Ok(36)
+## Any codeunit parser accepts a lowercase ASCII byte.
+expect {
+	actual = String.parse_str(String.any_codeunit, "a")?
+	actual == 'a'
+}
 
+## Any codeunit parser accepts a dollar-sign byte.
+expect {
+	actual = String.parse_str(String.any_codeunit, "\$")?
+	actual == 36
+}
+
+## Any input parser consumes all bytes and returns them.
 expect {
 	bytes = "consumes all the input".to_utf8()
-	Parser.parse(
+	actual = Parser.parse(
 		String.any_thing,
 		bytes,
 		|l| {
 			l.is_empty()
 		},
-	) == Ok(bytes)
+	)?
+	actual == bytes
 }
 
 # -------------------- example snippets used in docs --------------------
@@ -350,7 +374,11 @@ parse_u32 : Parser(String.Utf8, U32)
 parse_u32 = 
 	Parser.const(U64.to_u32_wrap).keep(String.digits)
 
-expect String.parse_str(parse_u32, "123") == Ok(123.U32)
+## Digit parsing can be mapped into a U32.
+expect {
+	actual = String.parse_str(parse_u32, "123")?
+	actual == 123.U32
+}
 
 color : Parser(String.Utf8, [Red, Green, Blue])
 color = 
@@ -362,14 +390,28 @@ color =
 		],
 	)
 
-expect String.parse_str(color, "green") == Ok(Green)
+## One-of parsing selects the matching color tag.
+expect {
+	actual = String.parse_str(color, "green")?
+	actual == Green
+}
 
 parse_numbers : Parser(String.Utf8, List(U64))
 parse_numbers = (String.digits).sep_by(String.codeunit(','))
 
-expect String.parse_str(parse_numbers, "1,2,3") == Ok([1, 2, 3])
+## Separator parsing returns the list of parsed numbers.
+expect {
+	actual = String.parse_str(parse_numbers, "1,2,3")?
+	actual == [1, 2, 3]
+}
 
-expect String.parse_str(String.string("Foo"), "Foo") == Ok("Foo")
+## Exact string parsing succeeds when the input matches.
+expect {
+	actual = String.parse_str(String.string("Foo"), "Foo")?
+	actual == "Foo"
+}
+
+## Exact string parsing reports non-matching input.
 expect String.parse_str(String.string("Foo"), "Bar").is_err()
 
 ignore_text : Parser(String.Utf8, U64)
@@ -383,7 +425,11 @@ ignore_text =
 		.skip(String.codeunit(':'))
 		.keep(String.digits)
 
-expect String.parse_str(ignore_text, "ignore preceding text:123") == Ok(123)
+## Skipping a prefix can parse the numeric suffix.
+expect {
+	actual = String.parse_str(ignore_text, "ignore preceding text:123")?
+	actual == 123
+}
 
 ignore_numbers : Parser(String.Utf8, Str)
 ignore_numbers = 
@@ -401,25 +447,42 @@ ignore_numbers =
 		)
 		.keep(String.string("TEXT"))
 
-expect String.parse_str(ignore_numbers, "0123456789876543210TEXT") == Ok("TEXT")
+## Chomping digits can leave the following text parser result.
+expect {
+	actual = String.parse_str(ignore_numbers, "0123456789876543210TEXT")?
+	actual == "TEXT"
+}
 
 is_digit : U8 -> Bool
 is_digit = |b| {
 	b >= '0' and b <= '9'
 }
 
-expect String.parse_str(String.codeunit_satisfies(is_digit), "0") == Ok('0')
+## Codeunit predicates can accept digit bytes.
+expect {
+	actual = String.parse_str(String.codeunit_satisfies(is_digit), "0")?
+	actual == '0'
+}
+
+## Codeunit predicates reject bytes that do not satisfy the predicate.
 expect String.parse_str(String.codeunit_satisfies(is_digit), "*").is_err()
 
 at_sign : Parser(String.Utf8, [AtSign])
 at_sign = Parser.const(AtSign).skip(String.codeunit('@'))
 
-expect String.parse_str(at_sign, "@") == Ok(AtSign)
-expect String.parse_str_partial(at_sign, "@").map_ok(
-	|r| {
-		r.val
-	},
-) == Ok(AtSign)
+## The at-sign parser succeeds on an at-sign byte.
+expect {
+	actual = String.parse_str(at_sign, "@")?
+	actual == AtSign
+}
+
+## Partial parsing returns the parsed at-sign tag.
+expect {
+	actual = String.parse_str_partial(at_sign, "@")?
+	actual.val == AtSign
+}
+
+## The at-sign parser rejects other bytes.
 expect String.parse_str_partial(at_sign, "\$").is_err()
 
 Requirement : [Green(U64), Red(U64), Blue(U64)]
@@ -460,24 +523,36 @@ parse_game = |s| {
 	}
 }
 
+## Game parsing extracts requirements grouped by reveal.
 expect {
-	parse_game("Game 1: 3 blue, 4 red; 1 red, 2 green, 6 blue; 2 green")
-		== Ok(
-			{
-				id: 1,
-				requirements: [
-					[Blue(3), Red(4)],
-					[Red(1), Green(2), Blue(6)],
-					[Green(2)],
-				],
-			},
-		)
+	actual = parse_game("Game 1: 3 blue, 4 red; 1 red, 2 green, 6 blue; 2 green")?
+	actual
+		== {
+			id: 1,
+			requirements: [
+				[Blue(3), Red(4)],
+				[Red(1), Green(2), Blue(6)],
+				[Green(2)],
+			],
+		}
 }
 
-expect String.parse_str(String.digit, "0") == Ok(0)
+## Single digit parsing converts ASCII zero into numeric zero.
+expect {
+	actual = String.parse_str(String.digit, "0")?
+	actual == 0
+}
+
+## Single digit parsing rejects non-digit text.
 expect String.parse_str(String.digit, "not a digit").is_err()
 
-expect String.parse_str(String.digits, "0123") == Ok(123)
+## Multiple digit parsing accepts leading zeroes.
+expect {
+	actual = String.parse_str(String.digits, "0123")?
+	actual == 123
+}
+
+## Multiple digit parsing rejects text without a leading digit.
 expect String.parse_str(String.digits, "not a digit").is_err()
 
 bool_parser : Parser(String.Utf8, Bool)
@@ -489,6 +564,17 @@ bool_parser =
 			},
 		)
 
-expect String.parse_str(bool_parser, "true") == Ok(Bool.True)
-expect String.parse_str(bool_parser, "false") == Ok(Bool.False)
+## Boolean parser maps true text to Bool.True.
+expect {
+	actual = String.parse_str(bool_parser, "true")?
+	actual == Bool.True
+}
+
+## Boolean parser maps false text to Bool.False.
+expect {
+	actual = String.parse_str(bool_parser, "false")?
+	actual == Bool.False
+}
+
+## Boolean parser rejects other text.
 expect String.parse_str(bool_parser, "not a bool").is_err()

--- a/package/Xml.roc
+++ b/package/Xml.roc
@@ -11,6 +11,11 @@ Xml :: {
 }.{
 	Attribute : { name : Str, value : Str }
 
+	Encoding := [
+		Utf8Encoding,
+		OtherEncoding(Str),
+	]
+
 	Declaration : {
 		version : Version,
 		encoding : [Given(Encoding), Missing],
@@ -20,15 +25,12 @@ Xml :: {
 		after_dot : U8,
 	}.{
 		new : U8 -> Version
-		new = |after_dot| { { after_dot } }
+		new = |after_dot| {
+			{ after_dot }
+		}
 		is_eq : Version, Version -> Bool
 		is_eq = |v1, v2| v1.after_dot == v2.after_dot
 	}
-
-	Encoding : [
-		Utf8Encoding,
-		OtherEncoding(Str),
-	]
 
 	Node := [
 		Element(Str, List({ name : Str, value : Str }), List(Node)),
@@ -52,47 +54,43 @@ v1_dot0 = {
 	Xml.Version.new(0)
 }
 
+## Full XML parsing captures the declaration and root element.
 expect {
-	# xml to be parsed
-	result = String.parse_str(Xml.xml_parser, test_xml)
+	result = String.parse_str(Xml.xml_parser, test_xml)?
 
 	result
-		== Ok(
-			{
-				xml_declaration: Given(
-					{
-						version: v1_dot0,
-						encoding: Given(Utf8Encoding),
-					},
-				),
-				root: Element(
-					"root",
-					[],
-					[
-						Text("\n    "),
-						Element(
-							"element",
-							[{ name: "arg", value: "value" }],
-							[],
-						),
-						Text("\n"),
-					],
-				),
-			},
-		)
+		== {
+			xml_declaration: Given(
+				{
+					version: v1_dot0,
+					encoding: Given(Utf8Encoding),
+				},
+			),
+			root: Element(
+				"root",
+				[],
+				[
+					Text("\n    "),
+					Element(
+						"element",
+						[{ name: "arg", value: "value" }],
+						[],
+					),
+					Text("\n"),
+				],
+			),
+		}
 }
 
+## XML parsing accepts documents without a prolog.
 expect {
-	# XML with empty prolog to be parsed
-	result = String.parse_str(Xml.xml_parser, "<element />")
+	result = String.parse_str(Xml.xml_parser, "<element />")?
 
 	result
-		== Ok(
-			{
-				xml_declaration: Missing,
-				root: Element("element", [], []),
-			},
-		)
+		== {
+			xml_declaration: Missing,
+			root: Element("element", [], []),
+		}
 }
 
 # See https://www.w3.org/TR/2008/REC-xml-20081126/#NT-prolog
@@ -134,22 +132,20 @@ p_xml_declaration =
 		.skip(p_whitespace.many())
 		.skip(String.string("?>"))
 
+## XML declaration parsing captures version and encoding.
 expect {
-	# XML declaration to be parsed
 	result = 
 		String.parse_str(
 			p_xml_declaration,
 			\\<?xml version="1.0" encoding="utf-8"?>
 			,
-		)
+		)?
 
 	result
-		== Ok(
-			{
-				version: v1_dot0,
-				encoding: Given(Utf8Encoding),
-			},
-		)
+		== {
+			version: v1_dot0,
+			encoding: Given(Utf8Encoding),
+		}
 }
 
 # See https://www.w3.org/TR/2008/REC-xml-20081126/#NT-VersionInfo
@@ -209,11 +205,11 @@ p_encoding_name =
 		)
 		.flatten()
 
+## UTF-8 encoding names parse as the Utf8Encoding tag.
 expect {
-	# encoding name to be parsed
-	result = String.parse_str(p_encoding_name, "utf-8")
+	result = String.parse_str(p_encoding_name, "utf-8")?
 
-	result == Ok(Utf8Encoding)
+	result == Utf8Encoding
 }
 
 # See https://www.w3.org/TR/2008/REC-xml-20081126/#NT-element
@@ -265,157 +261,147 @@ p_element =
 			),
 		)
 
+## Empty elements can include whitespace before the self-closing marker.
 expect {
-	# empty element tag without arguments to be parsed
-	result = String.parse_str(p_element, "<element />")
+	result = String.parse_str(p_element, "<element />")?
 
-	result == Ok(Element("element", [], []))
+	result == Element("element", [], [])
 }
 
+## Empty elements can omit whitespace before the self-closing marker.
 expect {
-	# empty element tag without arguments and without whitespace to be parsed
-	result = String.parse_str(p_element, "<element/>")
+	result = String.parse_str(p_element, "<element/>")?
 
-	result == Ok(Element("element", [], []))
+	result == Element("element", [], [])
 }
 
+## Empty elements can carry attributes.
 expect {
-	# empty element tag with argument to be parsed
 	result = String.parse_str(
 		p_element,
 		\\<element arg="value"/>
 		,
-	)
+	)?
 
-	result == Ok(Element("element", [{ name: "arg", value: "value" }], []))
+	result == Element("element", [{ name: "arg", value: "value" }], [])
 }
 
+## Explicit start and end tags can represent an empty element.
 expect {
-	# empty element without arguments to be parsed
-	result = String.parse_str(p_element, "<element></element>")
+	result = String.parse_str(p_element, "<element></element>")?
 
-	result == Ok(Element("element", [], []))
+	result == Element("element", [], [])
 }
 
+## Elements can parse multiple attributes and text content.
 expect {
-	# element with multiple arguments and text content to be parsed
 	result = String.parse_str(
 		p_element,
 		\\<element firstArg="one" secondArg="two">text content</element>
 		,
-	)
+	)?
 
 	result
-		== Ok(
-			Element(
-				"element",
-				[
-					{ name: "firstArg", value: "one" },
-					{ name: "secondArg", value: "two" },
-				],
-				[Text("text content")],
-			),
+		== Element(
+			"element",
+			[
+				{ name: "firstArg", value: "one" },
+				{ name: "secondArg", value: "two" },
+			],
+			[Text("text content")],
 		)
 }
 
+## CDATA sections parse into text nodes.
 expect {
-	# content with CDATA sections to be parsed
 	result = String.parse_str(
 		p_element,
 		"<element><![CDATA[<literal />]]></element>",
-	)
+	)?
 
 	result
-		== Ok(
-			Element(
-				"element",
-				[],
-				[Text("<literal />")],
-			),
+		== Element(
+			"element",
+			[],
+			[Text("<literal />")],
 		)
 }
 
+## Partial CDATA closing text is preserved until the real close marker.
 expect {
-	# CDATA section with partial CDATA section end tag to be parsed
 	result = String.parse_str(
 		p_element,
 		"<element><![CDATA[this is ]] not ]> the end]]></element>",
-	)
+	)?
 
 	result
-		== Ok(
-			Element(
-				"element",
-				[],
-				[Text("this is ]] not ]> the end")],
-			),
+		== Element(
+			"element",
+			[],
+			[Text("this is ]] not ]> the end")],
 		)
 }
 
+## Nested elements parse into child nodes.
 expect {
-	# nested elements to be parsed
 	result = String.parse_str(
 		p_element,
 		"<parent><child /></parent>",
-	)
+	)?
 
-	result == Ok(Element("parent", [], [Element("child", [], [])]))
+	result == Element("parent", [], [Element("child", [], [])])
 }
 
+## Nested elements preserve attributes on parent and child nodes.
 expect {
-	# nested element with arguments to be parsed
 	result = String.parse_str(
 		p_element,
 		\\<parent argParent="outer"><child argChild="inner" /></parent>
 		,
-	)
+	)?
 
 	result
-		== Ok(
-			Element(
-				"parent",
-				[
-					{ name: "argParent", value: "outer" },
-				],
-				[
-					Element(
-						"child",
-						[
-							{ name: "argChild", value: "inner" },
-						],
-						[],
-					),
-				],
-			),
+		== Element(
+			"parent",
+			[
+				{ name: "argParent", value: "outer" },
+			],
+			[
+				Element(
+					"child",
+					[
+						{ name: "argChild", value: "inner" },
+					],
+					[],
+				),
+			],
 		)
 }
 
+## Nested element parsing preserves whitespace text nodes.
 expect {
-	# nested elements with whitespace to be parsed
 	result = String.parse_str(
 		p_element,
 		\\<parent>
 		\\    <child />
 		\\</parent>
 		,
-	)
+	)?
 
 	result
-		== Ok(
-			Element(
-				"parent",
-				[],
-				[
-					Text("\n    "),
-					Element("child", [], []),
-					Text("\n"),
-				],
-			),
+		== Element(
+			"parent",
+			[],
+			[
+				Text("\n    "),
+				Element("child", [], []),
+				Text("\n"),
+			],
 		)
 }
 
+## Elements can parse a diverse set of child nodes.
 expect {
-	# element with diverse children to be parsed
 	result = String.parse_str(
 		p_element,
 		\\<feed xmlns="http://www.w3.org/2005/Atom">
@@ -424,37 +410,35 @@ expect {
 		\\    <updated>2024-02-23T20:38:24Z</updated>
 		\\</feed>
 		,
-	)
+	)?
 
 	result
-		== Ok(
-			Element(
-				"feed",
-				[{ name: "xmlns", value: "http://www.w3.org/2005/Atom" }],
-				[
-					Text("\n    "),
-					Element("title", [], [Text("Atom Feed")]),
-					Text("\n    "),
-					Element(
-						"link",
-						[
-							{ name: "rel", value: "self" },
-							{ name: "type", value: "application/atom+xml" },
-							{ name: "href", value: "http://example.org" },
-						],
-						[],
-					),
-					Text("\n    "),
-					Element(
-						"updated",
-						[],
-						[
-							Text("2024-02-23T20:38:24Z"),
-						],
-					),
-					Text("\n"),
-				],
-			),
+		== Element(
+			"feed",
+			[{ name: "xmlns", value: "http://www.w3.org/2005/Atom" }],
+			[
+				Text("\n    "),
+				Element("title", [], [Text("Atom Feed")]),
+				Text("\n    "),
+				Element(
+					"link",
+					[
+						{ name: "rel", value: "self" },
+						{ name: "type", value: "application/atom+xml" },
+						{ name: "href", value: "http://example.org" },
+					],
+					[],
+				),
+				Text("\n    "),
+				Element(
+					"updated",
+					[],
+					[
+						Text("2024-02-23T20:38:24Z"),
+					],
+				),
+				Text("\n"),
+			],
 		)
 }
 
@@ -703,10 +687,9 @@ trailing_whitespace_xml =
 	\\<root><Example></Example></root>
 	\\
 
+## Full XML parsing ignores trailing whitespace after the root.
 expect {
-	# ignore trailing newline
-	result : Try(Xml, _)
-	result = String.parse_str(Xml.xml_parser, trailing_whitespace_xml)
+	result = String.parse_str(Xml.xml_parser, trailing_whitespace_xml)?
 
 	expected : Xml
 	expected = {
@@ -725,5 +708,5 @@ expect {
 		),
 	}
 
-	result == Ok(expected)
+	result == expected
 }


### PR DESCRIPTION
## Summary
- Updated example apps from `roc-platform-template-zig` 0.9 to the 1.0.0 release tarball: https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst
- Added example `main!` annotations and propagated stdout/stderr effects with postfix `?` for the new platform API.
- Cleaned up parser expects with immediate `##` docs and postfix `?` happy-path setup; also fixed the exposed `Xml.Encoding` order needed by `roc check`.

## Tests
- `roc fmt --check package examples`
- `roc check package/main.roc`
- `./ci/all_tests.sh`