### PR TITLE
Expand Markdown parser for article body rendering

### DIFF
--- a/ci/test_bundle_examples.py
+++ b/ci/test_bundle_examples.py
@@ -18,7 +18,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_DEPENDENCY_RE = re.compile(r'(?m)^(\s*parser:\s*)"[^"]+"')
 SKIPPED_EXAMPLES = {
-    "markdown.roc": "latest nightly overflows the compiler stack while checking this example",
     "xml-svg.roc": "missing migrated roc-html dependency",
 }
 

--- a/examples/markdown.roc
+++ b/examples/markdown.roc
@@ -9,11 +9,15 @@ import parser.Markdown
 
 content : Str
 content =
-	\\# Title
+	\\# Title with **style**
 	\\
 	\\Intro with **bold**, `code`, and [a link](https://example.com).
 	\\
+	\\[roc website](https://roc-lang.org)
+	\\
 	\\![alt text](/images/logo.png)
+	\\
+	\\---
 	\\
 	\\## Sub-title
 	\\
@@ -23,7 +27,11 @@ content =
 	\\```
 	\\
 	\\- One
+	\\  continued
 	\\  - Nested
+	\\
+	\\1. First
+	\\2. Second
 	\\
 	\\> Quote with **strong** text
 
@@ -48,8 +56,8 @@ render_content = |nodes, buf| {
 		[] =>
 			buf # base case
 
-		[Heading(level, str), .. as rest] =>
-			render_content(rest, buf.concat("HEADING: ${Str.inspect(level)} ${str}\n"))
+		[Heading(level, inlines), .. as rest] =>
+			render_content(rest, buf.concat("HEADING: ${Str.inspect(level)} ${render_inlines(inlines, "")}\n"))
 
 		[Paragraph(inlines), .. as rest] =>
 			render_content(rest, buf.concat("PARAGRAPH: ${render_inlines(inlines, "")}\n"))
@@ -60,8 +68,14 @@ render_content = |nodes, buf| {
 		[UnorderedList(items), .. as rest] =>
 			render_content(rest, buf.concat("LIST:\n").concat(render_list_items(items, "")))
 
+		[OrderedList(items), .. as rest] =>
+			render_content(rest, buf.concat("ORDERED LIST:\n").concat(render_ordered_list_items(items, 1, "")))
+
 		[ListItem(inlines, children), .. as rest] =>
 			render_content(rest, buf.concat("ITEM: ${render_inlines(inlines, "")}\n").concat(render_content(children, "")))
+
+		[HorizontalRule, .. as rest] =>
+			render_content(rest, buf.concat("HORIZONTAL RULE\n"))
 
 		[Link({ alt, href }), .. as rest] =>
 			render_content(rest, buf.concat("LINK: alt: ${Str.inspect(alt)}, ref: ${Str.inspect(href)}\n"))
@@ -88,6 +102,20 @@ render_list_items = |items, buf| {
 
 		[other, .. as rest] =>
 			render_list_items(rest, buf.concat(render_content([other], "")))
+	}
+}
+
+render_ordered_list_items : List(Markdown.Markdown), U64, Str -> Str
+render_ordered_list_items = |items, index, buf| {
+	match items {
+		[] =>
+			buf
+
+		[ListItem(inlines, children), .. as rest] =>
+			render_ordered_list_items(rest, index + 1, buf.concat("${index.to_str()}. ${render_inlines(inlines, "")}\n").concat(render_content(children, "")))
+
+		[other, .. as rest] =>
+			render_ordered_list_items(rest, index, buf.concat(render_content([other], "")))
 	}
 }
 

--- a/examples/markdown.roc
+++ b/examples/markdown.roc
@@ -71,7 +71,7 @@ render_content = |nodes, buf| {
 			render_content(rest, buf.concat("BLOCKQUOTE:\n").concat(render_content(children, "")))
 
 		[ListBlock({ kind, loose, items }), .. as rest] =>
-			render_content(rest, buf.concat("LIST ${render_list_kind(kind)} loose=${render_bool(loose)}:\n").concat(render_list_items(items, "")))
+			render_content(rest, buf.concat("LIST ${kind.to_str()} loose=${render_bool(loose)}:\n").concat(render_list_items(items, "")))
 
 		[Code({ info, pre }), .. as rest] =>
 			render_content(rest, buf.concat("CODE: info: ${Str.inspect(info)}, pre: ${Str.inspect(pre)}\n"))
@@ -93,17 +93,6 @@ render_content = |nodes, buf| {
 	}
 }
 
-render_list_kind : Markdown.ListKind -> Str
-render_list_kind = |kind| {
-	match kind {
-		Unordered =>
-			"unordered"
-
-		Ordered({ start }) =>
-			"ordered:${start.to_str()}"
-	}
-}
-
 render_list_items : List({ task : Markdown.TaskState, blocks : List(Markdown.Markdown) }), Str -> Str
 render_list_items = |items, buf| {
 	match items {
@@ -111,37 +100,13 @@ render_list_items = |items, buf| {
 			buf
 
 		[item, .. as rest] =>
-			render_list_items(rest, buf.concat("- ${render_task(item.task)}\n").concat(render_content(item.blocks, "")))
-	}
-}
-
-render_task : Markdown.TaskState -> Str
-render_task = |task| {
-	match task {
-		NoTask =>
-			""
-
-		Unchecked =>
-			"[ ]"
-
-		Checked =>
-			"[x]"
+			render_list_items(rest, buf.concat("- ${item.task.to_str()}\n").concat(render_content(item.blocks, "")))
 	}
 }
 
 render_alignments : List(Markdown.Alignment) -> Str
 render_alignments = |alignments| {
-	join_strs(alignments.map(render_alignment), ",")
-}
-
-render_alignment : Markdown.Alignment -> Str
-render_alignment = |alignment| {
-	match alignment {
-		Default => "default"
-		Left => "left"
-		Center => "center"
-		Right => "right"
-	}
+	join_strs(alignments.map(|alignment| alignment.to_str()), ",")
 }
 
 render_rows : List(List(List(Markdown.Inline))) -> Str

--- a/examples/markdown.roc
+++ b/examples/markdown.roc
@@ -9,35 +9,40 @@ import parser.Markdown
 
 content : Str
 content =
+	\\---
+	\\title: Demo
+	\\---
 	\\# Title with **style**
 	\\
-	\\Intro with **bold**, `code`, and [a link](https://example.com).
+	\\Intro with **bold**, ~~old text~~, `code`, ![alt](/image.png), and [a link](https://example.com).
 	\\
-	\\[roc website](https://roc-lang.org)
+	\\[roc]: https://roc-lang.org "Roc"
+	\\Read [Roc][roc] and <https://example.com>.
 	\\
-	\\![alt text](/images/logo.png)
-	\\
-	\\---
-	\\
-	\\## Sub-title
+	\\| Name | Count |
+	\\| :--- | ---: |
+	\\| **Roc** | `1|2` |
 	\\
 	\\```roc
 	\\# some code
 	\\foo = bar
 	\\```
 	\\
-	\\- One
-	\\  continued
+	\\- [x] One
 	\\  - Nested
 	\\
 	\\1. First
 	\\2. Second
 	\\
 	\\> Quote with **strong** text
+	\\
+	\\<section>
+	\\raw
+	\\</section>
 
 main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
-	parsed = 
+	parsed =
 		String.parse_str(Markdown.all, content)
 			.map_ok(
 				|nodes| {
@@ -54,9 +59,9 @@ render_content : List(Markdown.Markdown), Str -> Str
 render_content = |nodes, buf| {
 	match nodes {
 		[] =>
-			buf # base case
+			buf
 
-		[Heading(level, inlines), .. as rest] =>
+		[Heading({ level, content: inlines }), .. as rest] =>
 			render_content(rest, buf.concat("HEADING: ${Str.inspect(level)} ${render_inlines(inlines, "")}\n"))
 
 		[Paragraph(inlines), .. as rest] =>
@@ -65,57 +70,122 @@ render_content = |nodes, buf| {
 		[Blockquote(children), .. as rest] =>
 			render_content(rest, buf.concat("BLOCKQUOTE:\n").concat(render_content(children, "")))
 
-		[UnorderedList(items), .. as rest] =>
-			render_content(rest, buf.concat("LIST:\n").concat(render_list_items(items, "")))
+		[ListBlock({ kind, loose, items }), .. as rest] =>
+			render_content(rest, buf.concat("LIST ${render_list_kind(kind)} loose=${render_bool(loose)}:\n").concat(render_list_items(items, "")))
 
-		[OrderedList(items), .. as rest] =>
-			render_content(rest, buf.concat("ORDERED LIST:\n").concat(render_ordered_list_items(items, 1, "")))
+		[Code({ info, pre }), .. as rest] =>
+			render_content(rest, buf.concat("CODE: info: ${Str.inspect(info)}, pre: ${Str.inspect(pre)}\n"))
 
-		[ListItem(inlines, children), .. as rest] =>
-			render_content(rest, buf.concat("ITEM: ${render_inlines(inlines, "")}\n").concat(render_content(children, "")))
+		[ThematicBreak, .. as rest] =>
+			render_content(rest, buf.concat("THEMATIC BREAK\n"))
 
-		[HorizontalRule, .. as rest] =>
-			render_content(rest, buf.concat("HORIZONTAL RULE\n"))
+		[Table({ header, align, rows }), .. as rest] =>
+			render_content(rest, buf.concat("TABLE: ${render_cells(header)} | ${render_alignments(align)} | ${render_rows(rows)}\n"))
 
-		[Link({ alt, href }), .. as rest] =>
-			render_content(rest, buf.concat("LINK: alt: ${Str.inspect(alt)}, ref: ${Str.inspect(href)}\n"))
+		[HtmlBlock(raw), .. as rest] =>
+			render_content(rest, buf.concat("HTML: ${Str.inspect(raw)}\n"))
 
-		[Image({ alt, href }), .. as rest] =>
-			render_content(rest, buf.concat("IMAGE: alt: ${Str.inspect(alt)}, ref: ${Str.inspect(href)}\n"))
-
-		[Code({ ext, pre }), .. as rest] =>
-			render_content(rest, buf.concat("CODE: ext: ${Str.inspect(ext)}, pre: ${Str.inspect(pre)}\n"))
+		[Frontmatter({ raw }), .. as rest] =>
+			render_content(rest, buf.concat("FRONTMATTER: ${Str.inspect(raw)}\n"))
 
 		[TODO(line), .. as rest] =>
 			render_content(rest, buf.concat("TODO: ${line}\n"))
 	}
 }
 
-render_list_items : List(Markdown.Markdown), Str -> Str
+render_list_kind : Markdown.ListKind -> Str
+render_list_kind = |kind| {
+	match kind {
+		Unordered =>
+			"unordered"
+
+		Ordered({ start }) =>
+			"ordered:${start.to_str()}"
+	}
+}
+
+render_list_items : List({ task : Markdown.TaskState, blocks : List(Markdown.Markdown) }), Str -> Str
 render_list_items = |items, buf| {
 	match items {
 		[] =>
 			buf
 
-		[ListItem(inlines, children), .. as rest] =>
-			render_list_items(rest, buf.concat("- ${render_inlines(inlines, "")}\n").concat(render_content(children, "")))
-
-		[other, .. as rest] =>
-			render_list_items(rest, buf.concat(render_content([other], "")))
+		[item, .. as rest] =>
+			render_list_items(rest, buf.concat("- ${render_task(item.task)}\n").concat(render_content(item.blocks, "")))
 	}
 }
 
-render_ordered_list_items : List(Markdown.Markdown), U64, Str -> Str
-render_ordered_list_items = |items, index, buf| {
+render_task : Markdown.TaskState -> Str
+render_task = |task| {
+	match task {
+		NoTask =>
+			""
+
+		Unchecked =>
+			"[ ]"
+
+		Checked =>
+			"[x]"
+	}
+}
+
+render_alignments : List(Markdown.Alignment) -> Str
+render_alignments = |alignments| {
+	join_strs(alignments.map(render_alignment), ",")
+}
+
+render_alignment : Markdown.Alignment -> Str
+render_alignment = |alignment| {
+	match alignment {
+		Default => "default"
+		Left => "left"
+		Center => "center"
+		Right => "right"
+	}
+}
+
+render_rows : List(List(List(Markdown.Inline))) -> Str
+render_rows = |rows| {
+	join_strs(rows.map(render_cells), ";")
+}
+
+render_cells : List(List(Markdown.Inline)) -> Str
+render_cells = |cells| {
+	join_strs(
+		cells.map(
+			|cell| {
+				render_inlines(cell, "")
+			},
+		),
+		"|",
+	)
+}
+
+render_bool : Bool -> Str
+render_bool = |value| {
+	if value {
+		"true"
+	} else {
+		"false"
+	}
+}
+
+join_strs : List(Str), Str -> Str
+join_strs = |items, separator| {
+	join_strs_help(items, separator, "")
+}
+
+join_strs_help : List(Str), Str, Str -> Str
+join_strs_help = |items, separator, acc| {
 	match items {
 		[] =>
-			buf
+			acc
 
-		[ListItem(inlines, children), .. as rest] =>
-			render_ordered_list_items(rest, index + 1, buf.concat("${index.to_str()}. ${render_inlines(inlines, "")}\n").concat(render_content(children, "")))
+		[item, .. as rest] if acc.is_empty() =>
+			join_strs_help(rest, separator, item)
 
-		[other, .. as rest] =>
-			render_ordered_list_items(rest, index, buf.concat(render_content([other], "")))
+		[item, .. as rest] =>
+			join_strs_help(rest, separator, acc.concat(separator).concat(item))
 	}
 }
 
@@ -134,10 +204,22 @@ render_inlines = |inlines, buf| {
 		[Emphasis(children), .. as rest] =>
 			render_inlines(rest, buf.concat("*").concat(render_inlines(children, "")).concat("*"))
 
+		[Strikethrough(children), .. as rest] =>
+			render_inlines(rest, buf.concat("~~").concat(render_inlines(children, "")).concat("~~"))
+
 		[InlineCode(code), .. as rest] =>
 			render_inlines(rest, buf.concat("`").concat(code).concat("`"))
 
-		[InlineLink({ alt, href }), .. as rest] =>
-			render_inlines(rest, buf.concat("[").concat(render_inlines(alt, "")).concat("](").concat(href).concat(")"))
+		[Link({ label, target }), .. as rest] =>
+			render_inlines(rest, buf.concat("[").concat(render_inlines(label, "")).concat("](").concat(target.href).concat(")"))
+
+		[Image({ alt, target }), .. as rest] =>
+			render_inlines(rest, buf.concat("![").concat(render_inlines(alt, "")).concat("](").concat(target.href).concat(")"))
+
+		[HardBreak, .. as rest] =>
+			render_inlines(rest, buf.concat("\\n"))
+
+		[HtmlInline(raw), .. as rest] =>
+			render_inlines(rest, buf.concat(raw))
 	}
 }

--- a/examples/markdown.roc
+++ b/examples/markdown.roc
@@ -8,12 +8,12 @@ import parser.String
 import parser.Markdown
 
 content : Str
-content = 
+content =
 	\\# Title
 	\\
-	\\This is some text
+	\\Intro with **bold**, `code`, and [a link](https://example.com).
 	\\
-	\\[roc website](https://roc-lang.org)
+	\\![alt text](/images/logo.png)
 	\\
 	\\## Sub-title
 	\\
@@ -21,6 +21,11 @@ content =
 	\\# some code
 	\\foo = bar
 	\\```
+	\\
+	\\- One
+	\\  - Nested
+	\\
+	\\> Quote with **strong** text
 
 main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
@@ -46,6 +51,18 @@ render_content = |nodes, buf| {
 		[Heading(level, str), .. as rest] =>
 			render_content(rest, buf.concat("HEADING: ${Str.inspect(level)} ${str}\n"))
 
+		[Paragraph(inlines), .. as rest] =>
+			render_content(rest, buf.concat("PARAGRAPH: ${render_inlines(inlines, "")}\n"))
+
+		[Blockquote(children), .. as rest] =>
+			render_content(rest, buf.concat("BLOCKQUOTE:\n").concat(render_content(children, "")))
+
+		[UnorderedList(items), .. as rest] =>
+			render_content(rest, buf.concat("LIST:\n").concat(render_list_items(items, "")))
+
+		[ListItem(inlines, children), .. as rest] =>
+			render_content(rest, buf.concat("ITEM: ${render_inlines(inlines, "")}\n").concat(render_content(children, "")))
+
 		[Link({ alt, href }), .. as rest] =>
 			render_content(rest, buf.concat("LINK: alt: ${Str.inspect(alt)}, ref: ${Str.inspect(href)}\n"))
 
@@ -57,5 +74,42 @@ render_content = |nodes, buf| {
 
 		[TODO(line), .. as rest] =>
 			render_content(rest, buf.concat("TODO: ${line}\n"))
-		}
+	}
+}
+
+render_list_items : List(Markdown.Markdown), Str -> Str
+render_list_items = |items, buf| {
+	match items {
+		[] =>
+			buf
+
+		[ListItem(inlines, children), .. as rest] =>
+			render_list_items(rest, buf.concat("- ${render_inlines(inlines, "")}\n").concat(render_content(children, "")))
+
+		[other, .. as rest] =>
+			render_list_items(rest, buf.concat(render_content([other], "")))
+	}
+}
+
+render_inlines : List(Markdown.Inline), Str -> Str
+render_inlines = |inlines, buf| {
+	match inlines {
+		[] =>
+			buf
+
+		[Text(text), .. as rest] =>
+			render_inlines(rest, buf.concat(text))
+
+		[Strong(children), .. as rest] =>
+			render_inlines(rest, buf.concat("**").concat(render_inlines(children, "")).concat("**"))
+
+		[Emphasis(children), .. as rest] =>
+			render_inlines(rest, buf.concat("*").concat(render_inlines(children, "")).concat("*"))
+
+		[InlineCode(code), .. as rest] =>
+			render_inlines(rest, buf.concat("`").concat(code).concat("`"))
+
+		[InlineLink({ alt, href }), .. as rest] =>
+			render_inlines(rest, buf.concat("[").concat(render_inlines(alt, "")).concat("](").concat(href).concat(")"))
+	}
 }

--- a/package/Markdown.roc
+++ b/package/Markdown.roc
@@ -3,26 +3,52 @@ import String
 
 # # Content values
 Markdown := [
-	Heading(Level, List(Inline)),
+	Heading({ level : Level, content : List(Inline) }),
 	Paragraph(List(Inline)),
 	Blockquote(List(Markdown)),
-	UnorderedList(List(Markdown)),
-	OrderedList(List(Markdown)),
-	ListItem(List(Inline), List(Markdown)),
-	HorizontalRule,
-	Link({ alt : Str, href : Str }),
-	Image({ alt : Str, href : Str }),
-	Code({ ext : Str, pre : Str }),
+	ListBlock({ kind : ListKind, loose : Bool, items : List({ task : TaskState, blocks : List(Markdown) }) }),
+	Code({ info : Str, pre : Str }),
+	ThematicBreak,
+	Table({ header : List(List(Inline)), align : List(Alignment), rows : List(List(List(Inline))) }),
+	HtmlBlock(Str),
+	Frontmatter({ raw : Str }),
 	TODO(Str),
 ].{
 	Level : [One, Two, Three, Four, Five, Six]
+
+	ListKind : [
+		Unordered,
+		Ordered({ start : U64 }),
+	]
+
+	TaskState : [
+		NoTask,
+		Unchecked,
+		Checked,
+	]
+
+	Alignment : [
+		Default,
+		Left,
+		Center,
+		Right,
+	]
+
+	LinkTarget : {
+		href : Str,
+		title : [Some(Str), None],
+	}
 
 	Inline := [
 		Text(Str),
 		Strong(List(Inline)),
 		Emphasis(List(Inline)),
+		Strikethrough(List(Inline)),
 		InlineCode(Str),
-		InlineLink({ alt : List(Inline), href : Str }),
+		Link({ label : List(Inline), target : LinkTarget }),
+		Image({ alt : List(Inline), target : LinkTarget }),
+		HardBreak,
+		HtmlInline(Str),
 	]
 
 	all : Parser(String.Utf8, List(Markdown))
@@ -31,12 +57,6 @@ Markdown := [
 	inlines : Parser(String.Utf8, List(Inline))
 	inlines = parse_inlines_parser
 
-	## Headings
-	##
-	## ```
-	## expect String.parse_str(heading, "# Foo Bar") == Ok(Heading(One, [Text("Foo Bar")]))
-	## expect String.parse_str(heading, "Foo Bar\n---") == Ok(Heading(Two, [Text("Foo Bar")]))
-	## ```
 	heading : Parser(String.Utf8, Markdown)
 	heading =
 		Parser.one_of(
@@ -47,17 +67,12 @@ Markdown := [
 			],
 		)
 
-	## Links
-	##
-	## ```roc
-	## expect String.parse_str(link, "[roc](https://roc-lang.org)") == Ok(Link({ alt: "roc", href: "https://roc-lang.org" }))
-	## ```
-	link : Parser(String.Utf8, Markdown)
+	link : Parser(String.Utf8, Inline)
 	link =
 		Parser.const(
-			|alt| {
-				|href| {
-					Link({ alt, href })
+			|label| {
+				|target| {
+					Link({ label: parse_inlines(label.to_utf8()), target: parse_link_target(target.to_utf8()) })
 				}
 			},
 		)
@@ -79,17 +94,12 @@ Markdown := [
 			)
 			.skip(String.codeunit(')'))
 
-	## Images
-	##
-	## ```roc
-	## expect String.parse_str(image, "![alt text](/images/logo.png)") == Ok(Image({ alt: "alt text", href: "/images/logo.png" }))
-	## ```
-	image : Parser(String.Utf8, Markdown)
+	image : Parser(String.Utf8, Inline)
 	image =
 		Parser.const(
 			|alt| {
-				|href| {
-					Image({ alt, href })
+				|target| {
+					Image({ alt: parse_inlines(alt.to_utf8()), target: parse_link_target(target.to_utf8()) })
 				}
 			},
 		)
@@ -111,34 +121,16 @@ Markdown := [
 			)
 			.skip(String.codeunit(')'))
 
-	## Parse code blocks using triple backticks
-	## supports block extension e.g. ```roc
-	##
-	## ```roc
-	## expect {
-	##     text =
-	##         \\```roc
-	##         \\# some code
-	##         \\foo = bar
-	##         \\```
-	##
-	##     a = String.parse_str(code, text)
-	##     a == Ok(Code({ ext: "roc", pre: "# some code\nfoo = bar\n" }))
-	## }
-	## ```
 	code : Parser(String.Utf8, Markdown)
 	code =
-		Parser.const(|ext| |pre| Code({ ext, pre }))
+		Parser.const(|info| |pre| Code({ info: info, pre: pre }))
 			.keep(
 				Parser.one_of(
 					[
-						# parse backticks with ext e.g. ```roc
 						Parser.const(|i| i)
 							.skip(String.string("```"))
 							.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
 							.skip(end_of_line),
-
-						# parse just backticks e.g. ```
 						Parser.const("")
 							.skip(String.string("```")),
 					],
@@ -149,16 +141,45 @@ Markdown := [
 
 Line : { raw : String.Utf8 }
 
+ReferenceDefinition : {
+	label : Str,
+	target : Markdown.LinkTarget,
+}
+
+DocumentParts : {
+	frontmatter : [Some(Markdown), None],
+	refs : List(ReferenceDefinition),
+	lines : List(Line),
+}
+
+ListMarker : {
+	kind : Markdown.ListKind,
+	width : U64,
+	content : String.Utf8,
+}
+
+Fence : {
+	marker : U8,
+	len : U64,
+	info : Str,
+}
+
 parse_all : Parser(String.Utf8, List(Markdown))
 parse_all =
 	Parser.build_primitive_parser(
 		|input| {
-			lines = split_lines(input)
-			parsed = parse_blocks_from_lines(lines, 0)?
+			prepared = prepare_document(split_lines(input))
+			parsed = parse_blocks_from_lines(prepared.lines, 0, prepared.refs)?
+
+			blocks =
+				match prepared.frontmatter {
+					Some(block) => List.prepend(parsed.val, block)
+					None => parsed.val
+				}
 
 			match parsed.input {
 				[] =>
-					Ok({ val: parsed.val, input: [] })
+					Ok({ val: blocks, input: [] })
 
 				_ =>
 					Err(ParsingFailure("unexpected unparsed markdown lines"))
@@ -166,81 +187,176 @@ parse_all =
 		},
 	)
 
-parse_blocks_from_lines : List(Line), U64 -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
-parse_blocks_from_lines = |lines, min_indent| {
-	parse_blocks_help(lines, min_indent, [])
+prepare_document : List(Line) -> DocumentParts
+prepare_document = |lines| {
+	front = take_frontmatter(lines)
+	without_front =
+		match front.frontmatter {
+			Some(_) => front.input
+			None => lines
+		}
+
+	refs = collect_reference_definitions(without_front, [], [])
+
+	{ frontmatter: front.frontmatter, refs: refs.refs, lines: refs.lines }
 }
 
-parse_blocks_help : List(Line), U64, List(Markdown) -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
-parse_blocks_help = |lines, min_indent, blocks| {
+take_frontmatter : List(Line) -> { frontmatter : [Some(Markdown), None], input : List(Line) }
+take_frontmatter = |lines| {
+	match lines {
+		[first, .. as rest] if is_exact_bytes(first.raw, "---".to_utf8()) => {
+			found = take_until_frontmatter_close(rest, [])
+
+			match found {
+				Ok(done) => {
+					raw = String.str_from_utf8(join_lines_with_newlines(done.raw))
+					{ frontmatter: Some(Frontmatter({ raw: raw })), input: done.input }
+				}
+
+				Err(_) =>
+					{ frontmatter: None, input: lines }
+			}
+		}
+
+		_ =>
+			{ frontmatter: None, input: lines }
+	}
+}
+
+take_until_frontmatter_close : List(Line), List(String.Utf8) -> Try({ raw : List(String.Utf8), input : List(Line) }, [NotFound])
+take_until_frontmatter_close = |lines, acc| {
+	match lines {
+		[] =>
+			Err(NotFound)
+
+		[line, .. as rest] if is_exact_bytes(line.raw, "---".to_utf8()) =>
+			Ok({ raw: acc, input: rest })
+
+		[line, .. as rest] =>
+			take_until_frontmatter_close(rest, acc.append(line.raw))
+	}
+}
+
+collect_reference_definitions : List(Line), List(ReferenceDefinition), List(Line) -> { refs : List(ReferenceDefinition), lines : List(Line) }
+collect_reference_definitions = |lines, refs, kept| {
+	match lines {
+		[] =>
+			{ refs: refs, lines: kept }
+
+		[line, .. as rest] => {
+			match parse_reference_definition(line.raw) {
+				Ok(ref) =>
+					collect_reference_definitions(rest, refs.append(ref), kept)
+
+				Err(_) =>
+					collect_reference_definitions(rest, refs, kept.append(line))
+			}
+		}
+	}
+}
+
+parse_reference_definition : String.Utf8 -> Try(ReferenceDefinition, [NotFound])
+parse_reference_definition = |line| {
+	match trim_spaces(line) {
+		['[', .. as rest] => {
+			label = find_sequence(rest, "]:".to_utf8())?
+			target_text = trim_spaces(label.after)
+
+			if target_text.is_empty() {
+				Err(NotFound)
+			} else {
+				Ok({ label: normalize_reference_label(label.before), target: parse_link_target(target_text) })
+			}
+		}
+
+		_ =>
+			Err(NotFound)
+	}
+}
+
+parse_blocks_from_lines : List(Line), U64, List(ReferenceDefinition) -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
+parse_blocks_from_lines = |lines, min_indent, refs| {
+	parse_blocks_help(lines, min_indent, refs, [])
+}
+
+parse_blocks_help : List(Line), U64, List(ReferenceDefinition), List(Markdown) -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
+parse_blocks_help = |lines, min_indent, refs, blocks| {
 	match lines {
 		[] =>
 			Ok({ val: blocks, input: [] })
 
 		[line, .. as rest] if line_is_blank(line) =>
-			parse_blocks_help(rest, min_indent, blocks)
+			parse_blocks_help(rest, min_indent, refs, blocks)
 
 		[line, ..] if line_indent(line) < min_indent =>
 			Ok({ val: blocks, input: lines })
 
 		_ => {
-			parsed = parse_one_block(lines, min_indent)?
-			parse_blocks_help(parsed.input, min_indent, blocks.append(parsed.val))
+			parsed = parse_one_block(lines, min_indent, refs)?
+			parse_blocks_help(parsed.input, min_indent, refs, blocks.append(parsed.val))
 		}
 	}
 }
 
-parse_one_block : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
-parse_one_block = |lines, min_indent| {
+parse_one_block : List(Line), U64, List(ReferenceDefinition) -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_one_block = |lines, min_indent, refs| {
 	match lines {
 		[line, underline, .. as rest_after_heading] if can_be_setext_heading_text(line, min_indent) => {
 			match underline_level(underline, min_indent) {
 				Ok(level) =>
-					Ok({ val: Heading(level, parse_inlines(strip_indent(line, min_indent))), input: rest_after_heading })
+					Ok({ val: Heading({ level: level, content: parse_inlines_with_refs(refs, strip_indent(line, min_indent)) }), input: rest_after_heading })
 
 				Err(_) =>
-					parse_one_block_without_setext(lines, min_indent)
+					parse_one_block_without_setext(lines, min_indent, refs)
 			}
 		}
 
 		_ =>
-			parse_one_block_without_setext(lines, min_indent)
+			parse_one_block_without_setext(lines, min_indent, refs)
 	}
 }
 
-parse_one_block_without_setext : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
-parse_one_block_without_setext = |lines, min_indent| {
+parse_one_block_without_setext : List(Line), U64, List(ReferenceDefinition) -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_one_block_without_setext = |lines, min_indent, refs| {
 	match lines {
 		[] =>
 			Err(ParsingFailure("expected a markdown block"))
 
+		[line, ..] if line_indent(line) >= min_indent + 4 =>
+			parse_indented_code_block(lines, min_indent)
+
 		[line, .. as rest] => {
 			content = strip_indent(line, min_indent)
 
-			match parse_hash_heading_line(content) {
+			match parse_hash_heading_line(content, refs) {
 				Ok(block) =>
 					Ok({ val: block, input: rest })
 
-				Err(_) if is_code_fence_line(line, min_indent) =>
-					parse_code_block(lines, min_indent)
-
-				Err(_) if is_horizontal_rule_line(line, min_indent) =>
-					Ok({ val: HorizontalRule, input: rest })
-
 				Err(_) => {
-					match parse_image_line(content) {
-						Ok(block) =>
-							Ok({ val: block, input: rest })
+					match parse_fence_start(line, min_indent) {
+						Ok(fence) =>
+							parse_fenced_code_block(lines, min_indent, fence)
+
+						Err(_) if is_thematic_break_line(line, min_indent) =>
+							Ok({ val: ThematicBreak, input: rest })
 
 						Err(_) => {
-							if is_blockquote_line(line, min_indent) {
-								parse_blockquote(lines, min_indent)
-							} else if is_unordered_list_item_line(line, min_indent) {
-								parse_unordered_list(lines, min_indent)
-							} else if is_ordered_list_item_line(line, min_indent) {
-								parse_ordered_list(lines, min_indent)
-							} else {
-								parse_paragraph(lines, min_indent)
+							match parse_table_block(lines, min_indent, refs) {
+								Ok(table_block) =>
+									Ok(table_block)
+
+								Err(_) if is_html_block_line(line, min_indent) =>
+									parse_html_block(lines, min_indent)
+
+								Err(_) if is_blockquote_line(line, min_indent) =>
+									parse_blockquote(lines, min_indent, refs)
+
+								Err(_) => {
+									match parse_list_marker(line, min_indent) {
+										Ok(_) => parse_list_block(lines, min_indent, refs)
+										Err(_) => parse_paragraph(lines, min_indent, refs)
+									}
+								}
 							}
 						}
 					}
@@ -250,15 +366,15 @@ parse_one_block_without_setext = |lines, min_indent| {
 	}
 }
 
-parse_paragraph : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
-parse_paragraph = |lines, min_indent| {
+parse_paragraph : List(Line), U64, List(ReferenceDefinition) -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_paragraph = |lines, min_indent, refs| {
 	collected = collect_paragraph_lines(lines, min_indent, [])
 
 	if collected.val.is_empty() {
 		Err(ParsingFailure("expected a paragraph line"))
 	} else {
-		text = join_lines_with_spaces(collected.val)
-		Ok({ val: Paragraph(parse_inlines(text)), input: collected.input })
+		text = join_inline_lines(collected.val)
+		Ok({ val: Paragraph(parse_inlines_with_refs(refs, text)), input: collected.input })
 	}
 }
 
@@ -282,15 +398,13 @@ collect_paragraph_lines = |lines, min_indent, acc| {
 	}
 }
 
-parse_code_block : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
-parse_code_block = |lines, min_indent| {
+parse_fenced_code_block : List(Line), U64, Fence -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_fenced_code_block = |lines, min_indent, fence| {
 	match lines {
-		[line, .. as rest] => {
-			fence = strip_indent(line, min_indent)
-			ext = String.str_from_utf8(fence.drop_first(3))
-			code = collect_code_lines(rest, min_indent, [])?
+		[_line, .. as rest] => {
+			code = collect_fenced_code_lines(rest, min_indent, fence, [])?
 
-			Ok({ val: Code({ ext, pre: String.str_from_utf8(code.val) }), input: code.input })
+			Ok({ val: Code({ info: fence.info, pre: String.str_from_utf8(join_lines_with_newlines(code.val)) }), input: code.input })
 		}
 
 		[] =>
@@ -298,32 +412,60 @@ parse_code_block = |lines, min_indent| {
 	}
 }
 
-collect_code_lines : List(Line), U64, String.Utf8 -> Try({ val : String.Utf8, input : List(Line) }, [ParsingFailure(Str)])
-collect_code_lines = |lines, min_indent, pre| {
+collect_fenced_code_lines : List(Line), U64, Fence, List(String.Utf8) -> Try({ val : List(String.Utf8), input : List(Line) }, [ParsingFailure(Str)])
+collect_fenced_code_lines = |lines, min_indent, fence, acc| {
 	match lines {
 		[] =>
-			Err(ParsingFailure("expected closing ```"))
+			Err(ParsingFailure("expected closing code fence"))
 
-		[line, .. as rest] if is_code_fence_line(line, min_indent) =>
-			Ok({ val: pre, input: rest })
+		[line, .. as rest] if is_matching_fence_close(line, min_indent, fence) =>
+			Ok({ val: acc, input: rest })
 
 		[line, .. as rest] => {
-			body_line = 
+			body_line =
 				if line_indent(line) >= min_indent {
 					strip_indent(line, min_indent)
 				} else {
 					line.raw
 				}
 
-			collect_code_lines(rest, min_indent, append_line(pre, body_line))
+			collect_fenced_code_lines(rest, min_indent, fence, acc.append(body_line))
 		}
 	}
 }
 
-parse_blockquote : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
-parse_blockquote = |lines, min_indent| {
+parse_indented_code_block : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_indented_code_block = |lines, min_indent| {
+	collected = collect_indented_code_lines(lines, min_indent, [])
+
+	if collected.val.is_empty() {
+		Err(ParsingFailure("expected indented code"))
+	} else {
+		Ok({ val: Code({ info: "", pre: String.str_from_utf8(join_lines_with_newlines(collected.val)) }), input: collected.input })
+	}
+}
+
+collect_indented_code_lines : List(Line), U64, List(String.Utf8) -> { val : List(String.Utf8), input : List(Line) }
+collect_indented_code_lines = |lines, min_indent, acc| {
+	match lines {
+		[] =>
+			{ val: acc, input: [] }
+
+		[line, .. as rest] if line_is_blank(line) =>
+			collect_indented_code_lines(rest, min_indent, acc.append([]))
+
+		[line, .. as rest] if line_indent(line) >= min_indent + 4 =>
+			collect_indented_code_lines(rest, min_indent, acc.append(strip_indent(line, min_indent + 4)))
+
+		_ =>
+			{ val: acc, input: lines }
+	}
+}
+
+parse_blockquote : List(Line), U64, List(ReferenceDefinition) -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_blockquote = |lines, min_indent, refs| {
 	quoted = collect_blockquote_lines(lines, min_indent, [])
-	inner = parse_blocks_from_lines(quoted.val, 0)?
+	inner = parse_blocks_from_lines(quoted.val, 0, refs)?
 
 	Ok({ val: Blockquote(inner.val), input: quoted.input })
 }
@@ -334,49 +476,99 @@ collect_blockquote_lines = |lines, min_indent, acc| {
 		[] =>
 			{ val: acc, input: [] }
 
-		[line, .. as rest] if is_blockquote_line(line, min_indent) => {
-			content = strip_blockquote_marker(line, min_indent)
-			collect_blockquote_lines(rest, min_indent, acc.append({ raw: content }))
-		}
+		[line, .. as rest] if is_blockquote_line(line, min_indent) =>
+			collect_blockquote_lines(rest, min_indent, acc.append({ raw: strip_blockquote_marker(line, min_indent) }))
+
+		[line, .. as rest] if line_is_blank(line) =>
+			collect_blockquote_lines(rest, min_indent, acc.append({ raw: [] }))
 
 		_ =>
 			{ val: acc, input: lines }
 	}
 }
 
-parse_unordered_list : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
-parse_unordered_list = |lines, min_indent| {
-	parsed = parse_list_items(lines, min_indent, [], unordered_list_item_content)?
-	Ok({ val: UnorderedList(parsed.val), input: parsed.input })
-}
-
-parse_ordered_list : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
-parse_ordered_list = |lines, min_indent| {
-	parsed = parse_list_items(lines, min_indent, [], ordered_list_item_content)?
-	Ok({ val: OrderedList(parsed.val), input: parsed.input })
-}
-
-parse_list_items : List(Line), U64, List(Markdown), (Line, U64 -> Try(String.Utf8, [NotFound])) -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
-parse_list_items = |lines, min_indent, items, list_item_content| {
+parse_list_block : List(Line), U64, List(ReferenceDefinition) -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_list_block = |lines, min_indent, refs| {
 	match lines {
-		[line, .. as rest] => {
-			match list_item_content(line, min_indent) {
-				Ok(content) => {
-					content_indent = min_indent + 2
-					continuation = collect_list_item_continuation(rest, content_indent, [content])
-					children = parse_blocks_from_lines(continuation.input, content_indent)?
-					item = ListItem(parse_inlines(join_lines_with_spaces(continuation.val)), children.val)
-
-					parse_list_items(children.input, min_indent, items.append(item), list_item_content)
+		[first, ..] => {
+			match parse_list_marker(first, min_indent) {
+				Ok(marker) => {
+					parsed = parse_list_items(lines, min_indent, refs, marker.kind, [], Bool.False)?
+					Ok({ val: ListBlock({ kind: marker.kind, loose: parsed.loose, items: parsed.items }), input: parsed.input })
 				}
 
 				Err(_) =>
-					Ok({ val: items, input: lines })
+					Err(ParsingFailure("expected list item"))
+			}
+		}
+
+		[] =>
+			Err(ParsingFailure("expected list item"))
+	}
+}
+
+parse_list_items : List(Line), U64, List(ReferenceDefinition), Markdown.ListKind, List({ task : Markdown.TaskState, blocks : List(Markdown) }), Bool -> Try({ items : List({ task : Markdown.TaskState, blocks : List(Markdown) }), loose : Bool, input : List(Line) }, [ParsingFailure(Str)])
+parse_list_items = |lines, min_indent, refs, kind, items, loose| {
+	match lines {
+		[line, .. as rest] => {
+			match parse_list_marker(line, min_indent) {
+				Ok(marker) if list_kind_matches(kind, marker.kind) => {
+					item = parse_list_item_after_marker(marker, rest, min_indent, refs)?
+					parse_list_items(item.input, min_indent, refs, kind, items.append(item.item), loose or item.loose)
+				}
+
+				_ =>
+					Ok({ items, loose, input: lines })
+			}
+		}
+
+		[] =>
+			Ok({ items, loose, input: [] })
+	}
+}
+
+parse_list_item_after_marker : ListMarker, List(Line), U64, List(ReferenceDefinition) -> Try({ item : { task : Markdown.TaskState, blocks : List(Markdown) }, loose : Bool, input : List(Line) }, [ParsingFailure(Str)])
+parse_list_item_after_marker = |marker, rest, min_indent, refs| {
+	task = parse_task_marker(marker.content)
+	content_indent = min_indent + marker.width
+	continuation = collect_list_item_continuation(rest, content_indent, [task.content])
+	saw_blank_before_children = blank_line_keeps_list_loose(continuation.input, min_indent, content_indent)
+	children = parse_blocks_from_lines(continuation.input, content_indent, refs)?
+
+	content_text = join_inline_lines(continuation.val)
+	content_blocks =
+		if trim_spaces(content_text).is_empty() {
+			children.val
+		} else {
+			List.prepend(children.val, Paragraph(parse_inlines_with_refs(refs, content_text)))
+		}
+
+	blank = consume_blank_lines(children.input, Bool.False)
+	saw_blank_after_children = blank_line_keeps_list_loose(children.input, min_indent, content_indent)
+
+	Ok({ item: { task: task.task, blocks: content_blocks }, loose: saw_blank_before_children or saw_blank_after_children, input: blank.input })
+}
+
+blank_line_keeps_list_loose : List(Line), U64, U64 -> Bool
+blank_line_keeps_list_loose = |lines, min_indent, content_indent| {
+	match lines {
+		[line, ..] if line_is_blank(line) => {
+			after_blank = consume_blank_lines(lines, Bool.False)
+
+			match after_blank.input {
+				[next, ..] if line_indent(next) >= content_indent =>
+					Bool.True
+
+				[next, ..] if parse_list_marker(next, min_indent).is_ok() =>
+					Bool.True
+
+				_ =>
+					Bool.False
 			}
 		}
 
 		_ =>
-			Ok({ val: items, input: lines })
+			Bool.False
 	}
 }
 
@@ -400,6 +592,98 @@ collect_list_item_continuation = |lines, content_indent, acc| {
 	}
 }
 
+parse_table_block : List(Line), U64, List(ReferenceDefinition) -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_table_block = |lines, min_indent, refs| {
+	match lines {
+		[header, delimiter, .. as rest] if line_indent(header) >= min_indent and line_indent(delimiter) >= min_indent => {
+			match split_table_cells(strip_indent(header, min_indent)) {
+				Ok(header_cells) => {
+					match split_table_cells(strip_indent(delimiter, min_indent)) {
+						Ok(delimiter_cells) => {
+							align = parse_table_delimiter(delimiter_cells)?
+
+							if header_cells.len() != align.len() {
+								Err(ParsingFailure("table header and delimiter column counts differ"))
+							} else {
+								rows = collect_table_rows(rest, min_indent, refs, [])
+								parsed_header = List.from_iter(header_cells.iter().map(|cell| parse_inlines_with_refs(refs, trim_spaces(cell))))
+
+								Ok({ val: Table({ header: parsed_header, align, rows: rows.rows }), input: rows.input })
+							}
+						}
+
+						Err(_) =>
+							Err(ParsingFailure("expected table delimiter"))
+					}
+				}
+
+				Err(_) =>
+					Err(ParsingFailure("expected table header"))
+			}
+		}
+
+		_ =>
+			Err(ParsingFailure("expected table"))
+	}
+}
+
+collect_table_rows : List(Line), U64, List(ReferenceDefinition), List(List(List(Markdown.Inline))) -> { rows : List(List(List(Markdown.Inline))), input : List(Line) }
+collect_table_rows = |lines, min_indent, refs, rows| {
+	match lines {
+		[] =>
+			{ rows, input: [] }
+
+		[line, ..] if line_is_blank(line) =>
+			{ rows, input: lines }
+
+		[line, ..] if line_indent(line) < min_indent =>
+			{ rows, input: lines }
+
+		[line, ..] if is_block_start(line, min_indent) =>
+			{ rows, input: lines }
+
+		[line, .. as rest] => {
+			match split_table_cells(strip_indent(line, min_indent)) {
+				Ok(cells) => {
+					parsed = List.from_iter(cells.iter().map(|cell| parse_inlines_with_refs(refs, trim_spaces(cell))))
+					collect_table_rows(rest, min_indent, refs, rows.append(parsed))
+				}
+
+				Err(_) =>
+					{ rows, input: lines }
+			}
+		}
+	}
+}
+
+parse_html_block : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_html_block = |lines, min_indent| {
+	collected = collect_html_block(lines, min_indent, [])
+
+	if collected.val.is_empty() {
+		Err(ParsingFailure("expected HTML block"))
+	} else {
+		Ok({ val: HtmlBlock(String.str_from_utf8(join_lines_with_newlines(collected.val))), input: collected.input })
+	}
+}
+
+collect_html_block : List(Line), U64, List(String.Utf8) -> { val : List(String.Utf8), input : List(Line) }
+collect_html_block = |lines, min_indent, acc| {
+	match lines {
+		[] =>
+			{ val: acc, input: [] }
+
+		[line, ..] if line_is_blank(line) =>
+			{ val: acc, input: lines }
+
+		[line, ..] if line_indent(line) < min_indent =>
+			{ val: acc, input: lines }
+
+		[line, .. as rest] =>
+			collect_html_block(rest, min_indent, acc.append(strip_indent(line, min_indent)))
+	}
+}
+
 is_block_start : Line, U64 -> Bool
 is_block_start = |line, min_indent| {
 	if line_indent(line) < min_indent {
@@ -408,12 +692,11 @@ is_block_start = |line, min_indent| {
 		content = strip_indent(line, min_indent)
 
 		is_hash_heading_line(content)
-			or is_horizontal_rule_line(line, min_indent)
-			or is_code_fence_line(line, min_indent)
-			or parse_image_line(content).is_ok()
+			or is_thematic_break_line(line, min_indent)
+			or parse_fence_start(line, min_indent).is_ok()
+			or is_html_block_line(line, min_indent)
 			or is_blockquote_line(line, min_indent)
-			or is_unordered_list_item_line(line, min_indent)
-			or is_ordered_list_item_line(line, min_indent)
+			or parse_list_marker(line, min_indent).is_ok()
 	}
 }
 
@@ -422,18 +705,113 @@ can_be_setext_heading_text = |line, min_indent| {
 	(!line_is_blank(line)) and line_indent(line) >= min_indent and !is_block_start(line, min_indent)
 }
 
-underline_level : Line, U64 -> Try(Level, [NotFound])
+inline_heading =
+	Parser.const(
+		|level| {
+			|str| {
+				Heading({ level: level, content: parse_inlines(trim_closing_heading_marker(str.to_utf8())) })
+			}
+		},
+	)
+		.keep(
+			Parser.one_of(
+				[
+					Parser.const(One).skip(String.string("# ")),
+					Parser.const(Two).skip(String.string("## ")),
+					Parser.const(Three).skip(String.string("### ")),
+					Parser.const(Four).skip(String.string("#### ")),
+					Parser.const(Five).skip(String.string("##### ")),
+					Parser.const(Six).skip(String.string("###### ")),
+				],
+			),
+		)
+		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
+
+two_line_heading_level_one =
+	Parser.const(
+		|str| {
+			Heading({ level: One, content: parse_inlines(str.to_utf8()) })
+		},
+	)
+		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
+		.skip(end_of_line)
+		.skip(String.string("=="))
+		.skip(
+			Parser.chomp_while(
+				|b| {
+					not_end_of_line(b) and b == '='
+				},
+			),
+		)
+
+two_line_heading_level_two =
+	Parser.const(
+		|str| {
+			Heading({ level: Two, content: parse_inlines(str.to_utf8()) })
+		},
+	)
+		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
+		.skip(end_of_line)
+		.skip(String.string("--"))
+		.skip(
+			Parser.chomp_while(
+				|b| {
+					not_end_of_line(b) and b == '-'
+				},
+			),
+		)
+
+parse_hash_heading_line : String.Utf8, List(ReferenceDefinition) -> Try(Markdown, [NotFound])
+parse_hash_heading_line = |content, refs| {
+	hashes = count_leading_byte(content, '#', 0)
+
+	if hashes < 1 or hashes > 6 {
+		Err(NotFound)
+	} else {
+		after_hashes = content.drop_first(hashes)
+
+		match after_hashes {
+			[' ', .. as raw_text] => {
+				level = heading_level_from_count(hashes)?
+				Ok(Heading({ level: level, content: parse_inlines_with_refs(refs, trim_closing_heading_marker(raw_text)) }))
+			}
+
+			_ =>
+				Err(NotFound)
+		}
+	}
+}
+
+is_hash_heading_line : String.Utf8 -> Bool
+is_hash_heading_line = |content| {
+	parse_hash_heading_line(content, []).is_ok()
+}
+
+heading_level_from_count : U64 -> Try(Markdown.Level, [NotFound])
+heading_level_from_count = |count| {
+	match count {
+		1 => Ok(One)
+		2 => Ok(Two)
+		3 => Ok(Three)
+		4 => Ok(Four)
+		5 => Ok(Five)
+		6 => Ok(Six)
+		_ => Err(NotFound)
+	}
+}
+
+underline_level : Line, U64 -> Try(Markdown.Level, [NotFound])
 underline_level = |line, min_indent| {
 	if line_indent(line) != min_indent {
 		Err(NotFound)
 	} else {
-		content = strip_indent(line, min_indent)
+		content = trim_spaces(strip_indent(line, min_indent))
 
 		match content {
-			['=', '=', .. as rest] if all_bytes_are(rest, '=') =>
+			['=', '=', ..] if underline_rest_matches(content, '=') =>
 				Ok(One)
 
-			['-', '-', .. as rest] if all_bytes_are(rest, '-') =>
+			['-', '-', ..] if underline_rest_matches(content, '-') =>
 				Ok(Two)
 
 			_ =>
@@ -442,78 +820,88 @@ underline_level = |line, min_indent| {
 	}
 }
 
-parse_hash_heading_line : String.Utf8 -> Try(Markdown, [NotFound])
-parse_hash_heading_line = |content| {
-	match content {
-		['#', ' ', .. as text] =>
-			Ok(Heading(One, parse_inlines(text)))
-
-		['#', '#', ' ', .. as text] =>
-			Ok(Heading(Two, parse_inlines(text)))
-
-		['#', '#', '#', ' ', .. as text] =>
-			Ok(Heading(Three, parse_inlines(text)))
-
-		['#', '#', '#', '#', ' ', .. as text] =>
-			Ok(Heading(Four, parse_inlines(text)))
-
-		['#', '#', '#', '#', '#', ' ', .. as text] =>
-			Ok(Heading(Five, parse_inlines(text)))
-
-		['#', '#', '#', '#', '#', '#', ' ', .. as text] =>
-			Ok(Heading(Six, parse_inlines(text)))
-
-		_ =>
-			Err(NotFound)
-	}
+underline_rest_matches : String.Utf8, U8 -> Bool
+underline_rest_matches = |content, marker| {
+	all_bytes_are(content.drop_first(2), marker)
 }
 
-is_hash_heading_line : String.Utf8 -> Bool
-is_hash_heading_line = |content| {
-	parse_hash_heading_line(content).is_ok()
-}
+parse_fence_start : Line, U64 -> Try(Fence, [NotFound])
+parse_fence_start = |line, min_indent| {
+	if line_indent(line) < min_indent {
+		Err(NotFound)
+	} else {
+		content = strip_indent(line, min_indent)
 
-parse_image_line : String.Utf8 -> Try(Markdown, [NotFound])
-parse_image_line = |content| {
-	match content {
-		['!', '[', .. as rest] => {
-			label = find_sequence(rest, "](".to_utf8())?
-			href = find_sequence(label.after, ")".to_utf8())?
+		match content {
+			['`', '`', '`', ..] =>
+				parse_fence_start_help(content, '`')
 
-			if href.after.is_empty() {
-				Ok(Image({ alt: String.str_from_utf8(label.before), href: String.str_from_utf8(href.before) }))
-			} else {
+			['~', '~', '~', ..] =>
+				parse_fence_start_help(content, '~')
+
+			_ =>
 				Err(NotFound)
-			}
 		}
-
-		_ =>
-			Err(NotFound)
 	}
 }
 
-parse_link_line : String.Utf8 -> Try(Markdown, [NotFound])
-parse_link_line = |content| {
+parse_fence_start_help : String.Utf8, U8 -> Try(Fence, [NotFound])
+parse_fence_start_help = |content, marker| {
+	len = count_leading_byte(content, marker, 0)
+
+	if len < 3 {
+		Err(NotFound)
+	} else {
+		info = trim_spaces(content.drop_first(len))
+		Ok({ marker, len, info: String.str_from_utf8(info) })
+	}
+}
+
+is_matching_fence_close : Line, U64, Fence -> Bool
+is_matching_fence_close = |line, min_indent, fence| {
+	if line_indent(line) < min_indent {
+		Bool.False
+	} else {
+		content = trim_spaces(strip_indent(line, min_indent))
+		count = count_leading_byte(content, fence.marker, 0)
+		rest = content.drop_first(count)
+
+		count >= fence.len and rest.is_empty()
+	}
+}
+
+is_thematic_break_line : Line, U64 -> Bool
+is_thematic_break_line = |line, min_indent| {
+	if line_indent(line) != min_indent {
+		Bool.False
+	} else {
+		content = strip_indent(line, min_indent)
+
+		match first_non_space(content) {
+			Ok(marker) if marker == '-' or marker == '*' or marker == '_' =>
+				thematic_marker_count(content, marker, 0) >= 3
+
+			_ =>
+				Bool.False
+		}
+	}
+}
+
+thematic_marker_count : String.Utf8, U8, U64 -> U64
+thematic_marker_count = |content, marker, count| {
 	match content {
-		['[', .. as rest] => {
-			label = find_sequence(rest, "](".to_utf8())?
-			href = find_sequence(label.after, ")".to_utf8())?
+		[] =>
+			count
 
-			if href.after.is_empty() {
-				Ok(Link({ alt: String.str_from_utf8(label.before), href: String.str_from_utf8(href.before) }))
-			} else {
-				Err(NotFound)
-			}
-		}
+		[' ', .. as rest] =>
+			thematic_marker_count(rest, marker, count)
+
+		[first, .. as rest] if first == marker =>
+			thematic_marker_count(rest, marker, count + 1)
 
 		_ =>
-			Err(NotFound)
+			0
 	}
-}
-
-is_code_fence_line : Line, U64 -> Bool
-is_code_fence_line = |line, min_indent| {
-	line_indent(line) >= min_indent and starts_with_bytes(strip_indent(line, min_indent), "```".to_utf8())
 }
 
 is_blockquote_line : Line, U64 -> Bool
@@ -534,74 +922,89 @@ strip_blockquote_marker = |line, min_indent| {
 	}
 }
 
-is_unordered_list_item_line : Line, U64 -> Bool
-is_unordered_list_item_line = |line, min_indent| {
-	unordered_list_item_content(line, min_indent).is_ok()
-}
-
-unordered_list_item_content : Line, U64 -> Try(String.Utf8, [NotFound])
-unordered_list_item_content = |line, min_indent| {
-	if line_indent(line) == min_indent and starts_with_bytes(strip_indent(line, min_indent), "- ".to_utf8()) {
-		Ok(strip_indent(line, min_indent).drop_first(2))
-	} else {
-		Err(NotFound)
-	}
-}
-
-is_ordered_list_item_line : Line, U64 -> Bool
-is_ordered_list_item_line = |line, min_indent| {
-	ordered_list_item_content(line, min_indent).is_ok()
-}
-
-ordered_list_item_content : Line, U64 -> Try(String.Utf8, [NotFound])
-ordered_list_item_content = |line, min_indent| {
-	if line_indent(line) == min_indent {
-		ordered_marker_content(strip_indent(line, min_indent))
-	} else {
-		Err(NotFound)
-	}
-}
-
-ordered_marker_content : String.Utf8 -> Try(String.Utf8, [NotFound])
-ordered_marker_content = |content| {
-	match content {
-		[first, .. as rest] if is_digit_byte(first) =>
-			ordered_marker_content_help(rest)
-
-		_ =>
-			Err(NotFound)
-	}
-}
-
-ordered_marker_content_help : String.Utf8 -> Try(String.Utf8, [NotFound])
-ordered_marker_content_help = |content| {
-	match content {
-		['.', ' ', .. as rest] =>
-			Ok(rest)
-
-		[first, .. as rest] if is_digit_byte(first) =>
-			ordered_marker_content_help(rest)
-
-		_ =>
-			Err(NotFound)
-	}
-}
-
-is_horizontal_rule_line : Line, U64 -> Bool
-is_horizontal_rule_line = |line, min_indent| {
+parse_list_marker : Line, U64 -> Try(ListMarker, [NotFound])
+parse_list_marker = |line, min_indent| {
 	if line_indent(line) != min_indent {
-		Bool.False
+		Err(NotFound)
 	} else {
 		content = strip_indent(line, min_indent)
 
 		match content {
-			['-', '-', '-', .. as rest] if all_bytes_are(rest, '-') =>
-				Bool.True
+			['-', ' ', .. as rest] =>
+				Ok({ kind: Unordered, width: 2, content: rest })
 
-			['*', '*', '*', .. as rest] if all_bytes_are(rest, '*') =>
-				Bool.True
+			['*', ' ', .. as rest] =>
+				Ok({ kind: Unordered, width: 2, content: rest })
 
-			['_', '_', '_', .. as rest] if all_bytes_are(rest, '_') =>
+			['+', ' ', .. as rest] =>
+				Ok({ kind: Unordered, width: 2, content: rest })
+
+			[first, .. as rest] if is_digit_byte(first) =>
+				parse_ordered_marker(rest, [first])
+
+			_ =>
+				Err(NotFound)
+		}
+	}
+}
+
+parse_ordered_marker : String.Utf8, String.Utf8 -> Try(ListMarker, [NotFound])
+parse_ordered_marker = |content, digits| {
+	match content {
+		['.', ' ', .. as rest] =>
+			Ok({ kind: Ordered({ start: digits_to_u64(digits) }), width: digits.len() + 2, content: rest })
+
+		[')', ' ', .. as rest] =>
+			Ok({ kind: Ordered({ start: digits_to_u64(digits) }), width: digits.len() + 2, content: rest })
+
+		[first, .. as rest] if is_digit_byte(first) =>
+			parse_ordered_marker(rest, digits.append(first))
+
+		_ =>
+			Err(NotFound)
+	}
+}
+
+list_kind_matches : Markdown.ListKind, Markdown.ListKind -> Bool
+list_kind_matches = |expected, actual| {
+	match { expected, actual } {
+		{ expected: Unordered, actual: Unordered } =>
+			Bool.True
+
+		{ expected: Ordered(_), actual: Ordered(_) } =>
+			Bool.True
+
+		_ =>
+			Bool.False
+	}
+}
+
+parse_task_marker : String.Utf8 -> { task : Markdown.TaskState, content : String.Utf8 }
+parse_task_marker = |content| {
+	match content {
+		['[', ' ', ']', ' ', .. as rest] =>
+			{ task: Unchecked, content: rest }
+
+		['[', 'x', ']', ' ', .. as rest] =>
+			{ task: Checked, content: rest }
+
+		['[', 'X', ']', ' ', .. as rest] =>
+			{ task: Checked, content: rest }
+
+		_ =>
+			{ task: NoTask, content }
+	}
+}
+
+is_html_block_line : Line, U64 -> Bool
+is_html_block_line = |line, min_indent| {
+	if line_indent(line) < min_indent {
+		Bool.False
+	} else {
+		content = trim_spaces(strip_indent(line, min_indent))
+
+		match content {
+			['<', first, ..] if is_alphabetic_byte(first) or first == '/' or first == '!' =>
 				Bool.True
 
 			_ =>
@@ -610,12 +1013,180 @@ is_horizontal_rule_line = |line, min_indent| {
 	}
 }
 
-is_digit_byte : U8 -> Bool
-is_digit_byte = |byte| {
-	byte >= '0' and byte <= '9'
+split_table_cells : String.Utf8 -> Try(List(String.Utf8), [NotFound])
+split_table_cells = |line| {
+	if !contains_unescaped_pipe(line) {
+		Err(NotFound)
+	} else {
+		cells = split_table_cells_help(strip_outer_table_pipes(line), [], [], Bool.False, Bool.False)
+
+		if cells.is_empty() {
+			Err(NotFound)
+		} else {
+			Ok(cells)
+		}
+	}
 }
 
-parse_inlines_parser : Parser(String.Utf8, List(Inline))
+split_table_cells_help : String.Utf8, String.Utf8, List(String.Utf8), Bool, Bool -> List(String.Utf8)
+split_table_cells_help = |input, current, cells, in_code, escaped| {
+	match input {
+		[] =>
+			cells.append(current)
+
+		[first, .. as rest] if escaped =>
+			split_table_cells_help(rest, current.append(first), cells, in_code, Bool.False)
+
+		['\\', .. as rest] =>
+			split_table_cells_help(rest, current.append('\\'), cells, in_code, Bool.True)
+
+		['`', .. as rest] =>
+			split_table_cells_help(rest, current.append('`'), cells, !in_code, Bool.False)
+
+		['|', .. as rest] if !in_code =>
+			split_table_cells_help(rest, [], cells.append(current), in_code, Bool.False)
+
+		[first, .. as rest] =>
+			split_table_cells_help(rest, current.append(first), cells, in_code, Bool.False)
+	}
+}
+
+strip_outer_table_pipes : String.Utf8 -> String.Utf8
+strip_outer_table_pipes = |line| {
+	trimmed = trim_spaces(line)
+	left =
+		match trimmed {
+			['|', .. as rest] => rest
+			_ => trimmed
+		}
+
+	drop_trailing_pipe(trim_spaces(left))
+}
+
+drop_trailing_pipe : String.Utf8 -> String.Utf8
+drop_trailing_pipe = |bytes| {
+	drop_trailing_pipe_help(bytes, [], [])
+}
+
+drop_trailing_pipe_help : String.Utf8, String.Utf8, String.Utf8 -> String.Utf8
+drop_trailing_pipe_help = |bytes, out, pending_spaces| {
+	match bytes {
+		[] =>
+			out
+
+		[' ', .. as rest] =>
+			drop_trailing_pipe_help(rest, out, pending_spaces.append(' '))
+
+		['|'] =>
+			out
+
+		[first, .. as rest] =>
+			drop_trailing_pipe_help(rest, append_bytes(out, pending_spaces).append(first), [])
+	}
+}
+
+parse_table_delimiter : List(String.Utf8) -> Try(List(Markdown.Alignment), [ParsingFailure(Str)])
+parse_table_delimiter = |cells| {
+	align = List.from_iter(cells.iter().map(parse_alignment_cell))
+
+	if align_has_failure(align) {
+		Err(ParsingFailure("expected table delimiter"))
+	} else {
+		Ok(List.from_iter(align.iter().map(unwrap_alignment)))
+	}
+}
+
+parse_alignment_cell : String.Utf8 -> Try(Markdown.Alignment, [NotFound])
+parse_alignment_cell = |cell| {
+	trimmed = trim_spaces(cell)
+	left_colon = starts_with_bytes(trimmed, ":".to_utf8())
+	right_colon = ends_with_byte(trimmed, ':')
+	dashes = count_byte(trimmed, '-')
+
+	if dashes < 3 or !only_alignment_chars(trimmed) {
+		Err(NotFound)
+	} else if left_colon and right_colon {
+		Ok(Center)
+	} else if left_colon {
+		Ok(Left)
+	} else if right_colon {
+		Ok(Right)
+	} else {
+		Ok(Default)
+	}
+}
+
+align_has_failure : List(Try(Markdown.Alignment, [NotFound])) -> Bool
+align_has_failure = |items| {
+	match items {
+		[] =>
+			Bool.False
+
+		[Err(_), ..] =>
+			Bool.True
+
+		[Ok(_), .. as rest] =>
+			align_has_failure(rest)
+	}
+}
+
+unwrap_alignment : Try(Markdown.Alignment, [NotFound]) -> Markdown.Alignment
+unwrap_alignment = |item| {
+	match item {
+		Ok(align) => align
+		Err(_) => Default
+	}
+}
+
+only_alignment_chars : String.Utf8 -> Bool
+only_alignment_chars = |bytes| {
+	match bytes {
+		[] =>
+			Bool.True
+
+		['-', .. as rest] =>
+			only_alignment_chars(rest)
+
+		[':', .. as rest] =>
+			only_alignment_chars(rest)
+
+		[' ', .. as rest] =>
+			only_alignment_chars(rest)
+
+		_ =>
+			Bool.False
+	}
+}
+
+contains_unescaped_pipe : String.Utf8 -> Bool
+contains_unescaped_pipe = |bytes| {
+	contains_unescaped_pipe_help(bytes, Bool.False, Bool.False)
+}
+
+contains_unescaped_pipe_help : String.Utf8, Bool, Bool -> Bool
+contains_unescaped_pipe_help = |bytes, in_code, escaped| {
+	match bytes {
+		[] =>
+			Bool.False
+
+		[_, .. as rest] if escaped =>
+			contains_unescaped_pipe_help(rest, in_code, Bool.False)
+
+		['\\', .. as rest] =>
+			contains_unescaped_pipe_help(rest, in_code, Bool.True)
+
+		['`', .. as rest] =>
+			contains_unescaped_pipe_help(rest, !in_code, Bool.False)
+
+		['|', ..] if !in_code =>
+			Bool.True
+
+		[_, .. as rest] =>
+			contains_unescaped_pipe_help(rest, in_code, Bool.False)
+	}
+}
+
+parse_inlines_parser : Parser(String.Utf8, List(Markdown.Inline))
 parse_inlines_parser =
 	Parser.build_primitive_parser(
 		|input| {
@@ -623,56 +1194,113 @@ parse_inlines_parser =
 		},
 	)
 
-parse_inlines : String.Utf8 -> List(Inline)
+parse_inlines : String.Utf8 -> List(Markdown.Inline)
 parse_inlines = |input| {
-	parse_inlines_help(input, [], [])
+	parse_inlines_with_refs([], input)
 }
 
-parse_inlines_help : String.Utf8, String.Utf8, List(Inline) -> List(Inline)
-parse_inlines_help = |input, text, nodes| {
+parse_inlines_with_refs : List(ReferenceDefinition), String.Utf8 -> List(Markdown.Inline)
+parse_inlines_with_refs = |refs, input| {
+	parse_inlines_help(refs, input, [], [])
+}
+
+parse_inlines_help : List(ReferenceDefinition), String.Utf8, String.Utf8, List(Markdown.Inline) -> List(Markdown.Inline)
+parse_inlines_help = |refs, input, text, nodes| {
 	match input {
 		[] =>
 			flush_text(text, nodes)
 
+		[' ', ' ', '\n', .. as rest] => {
+			next_nodes = flush_text(text, nodes).append(HardBreak)
+			parse_inlines_help(refs, rest, [], next_nodes)
+		}
+
+		['\\', '\n', .. as rest] => {
+			next_nodes = flush_text(text, nodes).append(HardBreak)
+			parse_inlines_help(refs, rest, [], next_nodes)
+		}
+
 		['\\', escaped, .. as rest] if is_escapable_inline_byte(escaped) =>
-			parse_inlines_help(rest, text.append(escaped), nodes)
+			parse_inlines_help(refs, rest, text.append(escaped), nodes)
 
 		['\\', .. as rest] =>
-			parse_inlines_help(rest, text.append('\\'), nodes)
+			parse_inlines_help(refs, rest, text.append('\\'), nodes)
+
+		['!', '[', ..] => {
+			match parse_image_inline(input, refs) {
+				Ok(parsed) =>
+					parse_inlines_help(refs, parsed.input, [], flush_text(text, nodes).append(parsed.val))
+
+				Err(_) =>
+					parse_inlines_help(refs, input.drop_first(1), text.append('!'), nodes)
+			}
+		}
+
+		['[', ..] => {
+			match parse_link_inline(input, refs) {
+				Ok(parsed) =>
+					parse_inlines_help(refs, parsed.input, [], flush_text(text, nodes).append(parsed.val))
+
+				Err(_) =>
+					parse_inlines_help(refs, input.drop_first(1), text.append('['), nodes)
+			}
+		}
+
+		['<', ..] => {
+			match parse_angle_inline(input) {
+				Ok(parsed) =>
+					parse_inlines_help(refs, parsed.input, [], flush_text(text, nodes).append(parsed.val))
+
+				Err(_) =>
+					parse_inlines_help(refs, input.drop_first(1), text.append('<'), nodes)
+			}
+		}
+
+		['~', '~', .. as rest] => {
+			match find_unescaped_sequence(rest, "~~".to_utf8()) {
+				Ok(found) => {
+					next_nodes = flush_text(text, nodes).append(Strikethrough(parse_inlines_with_refs(refs, found.before)))
+					parse_inlines_help(refs, found.after, [], next_nodes)
+				}
+
+				Err(_) =>
+					parse_inlines_help(refs, rest, text.append('~').append('~'), nodes)
+			}
+		}
 
 		['*', '*', .. as rest] => {
 			match find_unescaped_sequence(rest, "**".to_utf8()) {
 				Ok(found) => {
-					next_nodes = flush_text(text, nodes).append(Strong(parse_inlines(found.before)))
-					parse_inlines_help(found.after, [], next_nodes)
+					next_nodes = flush_text(text, nodes).append(Strong(parse_inlines_with_refs(refs, found.before)))
+					parse_inlines_help(refs, found.after, [], next_nodes)
 				}
 
 				Err(_) =>
-					parse_inlines_help(rest, text.append('*').append('*'), nodes)
+					parse_inlines_help(refs, rest, text.append('*').append('*'), nodes)
 			}
 		}
 
 		['*', .. as rest] => {
 			match find_unescaped_sequence(rest, "*".to_utf8()) {
 				Ok(found) => {
-					next_nodes = flush_text(text, nodes).append(Emphasis(parse_inlines(found.before)))
-					parse_inlines_help(found.after, [], next_nodes)
+					next_nodes = flush_text(text, nodes).append(Emphasis(parse_inlines_with_refs(refs, found.before)))
+					parse_inlines_help(refs, found.after, [], next_nodes)
 				}
 
 				Err(_) =>
-					parse_inlines_help(rest, text.append('*'), nodes)
+					parse_inlines_help(refs, rest, text.append('*'), nodes)
 			}
 		}
 
 		['_', .. as rest] => {
 			match find_unescaped_sequence(rest, "_".to_utf8()) {
 				Ok(found) => {
-					next_nodes = flush_text(text, nodes).append(Emphasis(parse_inlines(found.before)))
-					parse_inlines_help(found.after, [], next_nodes)
+					next_nodes = flush_text(text, nodes).append(Emphasis(parse_inlines_with_refs(refs, found.before)))
+					parse_inlines_help(refs, found.after, [], next_nodes)
 				}
 
 				Err(_) =>
-					parse_inlines_help(rest, text.append('_'), nodes)
+					parse_inlines_help(refs, rest, text.append('_'), nodes)
 			}
 		}
 
@@ -680,54 +1308,157 @@ parse_inlines_help = |input, text, nodes| {
 			match find_unescaped_sequence(rest, "`".to_utf8()) {
 				Ok(found) => {
 					next_nodes = flush_text(text, nodes).append(InlineCode(String.str_from_utf8(found.before)))
-					parse_inlines_help(found.after, [], next_nodes)
+					parse_inlines_help(refs, found.after, [], next_nodes)
 				}
 
 				Err(_) =>
-					parse_inlines_help(rest, text.append('`'), nodes)
+					parse_inlines_help(refs, rest, text.append('`'), nodes)
 			}
 		}
 
-		['[', .. as rest] => {
-			match find_unescaped_sequence(rest, "](".to_utf8()) {
-				Ok(label) => {
-					match find_unescaped_sequence(label.after, ")".to_utf8()) {
-						Ok(href) => {
-							next_nodes =
-								flush_text(text, nodes)
-									.append(InlineLink({ alt: parse_inlines(label.before), href: String.str_from_utf8(href.before) }))
+		_ if starts_with_bytes(input, "https://".to_utf8()) or starts_with_bytes(input, "http://".to_utf8()) or starts_with_bytes(input, "www.".to_utf8()) => {
+			parsed = parse_bare_url(input)
+			target = { href: String.str_from_utf8(parsed.url), title: None }
+			node = Link({ label: [Text(String.str_from_utf8(parsed.url))], target })
 
-							parse_inlines_help(href.after, [], next_nodes)
-						}
-
-						Err(_) =>
-							parse_inlines_help(rest, text.append('['), nodes)
-					}
-				}
-
-				Err(_) =>
-					parse_inlines_help(rest, text.append('['), nodes)
-			}
+			parse_inlines_help(refs, parsed.input, [], flush_text(text, nodes).append(node))
 		}
 
 		[first, .. as rest] =>
-			parse_inlines_help(rest, text.append(first), nodes)
+			parse_inlines_help(refs, rest, text.append(first), nodes)
 	}
 }
 
-is_escapable_inline_byte : U8 -> Bool
-is_escapable_inline_byte = |byte| {
-	byte == '\\'
-		or byte == '*'
-		or byte == '_'
-		or byte == '`'
-		or byte == '['
-		or byte == ']'
-		or byte == '('
-		or byte == ')'
+parse_image_inline : String.Utf8, List(ReferenceDefinition) -> Try({ val : Markdown.Inline, input : String.Utf8 }, [NotFound])
+parse_image_inline = |input, refs| {
+	match input {
+		['!', '[', .. as rest] => {
+			label = find_unescaped_sequence(rest, "]".to_utf8())?
+			target = parse_link_or_reference_target(label.after, label.before, refs)?
+
+			Ok({ val: Image({ alt: parse_inlines_with_refs(refs, label.before), target: target.target }), input: target.input })
+		}
+
+		_ =>
+			Err(NotFound)
+	}
 }
 
-flush_text : String.Utf8, List(Inline) -> List(Inline)
+parse_link_inline : String.Utf8, List(ReferenceDefinition) -> Try({ val : Markdown.Inline, input : String.Utf8 }, [NotFound])
+parse_link_inline = |input, refs| {
+	match input {
+		['[', .. as rest] => {
+			label = find_unescaped_sequence(rest, "]".to_utf8())?
+			target = parse_link_or_reference_target(label.after, label.before, refs)?
+
+			Ok({ val: Link({ label: parse_inlines_with_refs(refs, label.before), target: target.target }), input: target.input })
+		}
+
+		_ =>
+			Err(NotFound)
+	}
+}
+
+parse_link_or_reference_target : String.Utf8, String.Utf8, List(ReferenceDefinition) -> Try({ target : Markdown.LinkTarget, input : String.Utf8 }, [NotFound])
+parse_link_or_reference_target = |input, label, refs| {
+	match input {
+		['(', .. as rest] => {
+			target_text = find_unescaped_sequence(rest, ")".to_utf8())?
+			Ok({ target: parse_link_target(target_text.before), input: target_text.after })
+		}
+
+		['[', ']', .. as rest] => {
+			target = lookup_reference(refs, normalize_reference_label(label))?
+			Ok({ target, input: rest })
+		}
+
+		['[', .. as rest] => {
+			ref_label = find_unescaped_sequence(rest, "]".to_utf8())?
+			target = lookup_reference(refs, normalize_reference_label(ref_label.before))?
+			Ok({ target, input: ref_label.after })
+		}
+
+		_ => {
+			target = lookup_reference(refs, normalize_reference_label(label))?
+			Ok({ target, input })
+		}
+	}
+}
+
+parse_angle_inline : String.Utf8 -> Try({ val : Markdown.Inline, input : String.Utf8 }, [NotFound])
+parse_angle_inline = |input| {
+	match input {
+		['<', .. as rest] => {
+			inside = find_sequence(rest, ">".to_utf8())?
+			inside_str = String.str_from_utf8(inside.before)
+
+			if starts_with_bytes(inside.before, "http://".to_utf8()) or starts_with_bytes(inside.before, "https://".to_utf8()) {
+				Ok({ val: Link({ label: [Text(inside_str)], target: { href: inside_str, title: None } }), input: inside.after })
+			} else if is_email_bytes(inside.before) {
+				Ok({ val: Link({ label: [Text(inside_str)], target: { href: "mailto:${inside_str}", title: None } }), input: inside.after })
+			} else {
+				raw = append_bytes("<".to_utf8(), append_bytes(inside.before, ">".to_utf8()))
+				Ok({ val: HtmlInline(String.str_from_utf8(raw)), input: inside.after })
+			}
+		}
+
+		_ =>
+			Err(NotFound)
+	}
+}
+
+parse_bare_url : String.Utf8 -> { url : String.Utf8, input : String.Utf8 }
+parse_bare_url = |input| {
+	parse_bare_url_help(input, [])
+}
+
+parse_bare_url_help : String.Utf8, String.Utf8 -> { url : String.Utf8, input : String.Utf8 }
+parse_bare_url_help = |input, url| {
+	match input {
+		[] =>
+			{ url, input: [] }
+
+		[first, ..] if first == ' ' or first == '\n' or first == '\t' =>
+			{ url, input }
+
+		[first, ..] if first == ')' or first == ']' =>
+			{ url, input }
+
+		[first, .. as rest] =>
+			parse_bare_url_help(rest, url.append(first))
+	}
+}
+
+parse_link_target : String.Utf8 -> Markdown.LinkTarget
+parse_link_target = |raw| {
+	clean = trim_spaces(raw)
+	parts = split_first_space(clean)
+
+	title =
+		if parts.rest.is_empty() {
+			None
+		} else {
+			Some(String.str_from_utf8(strip_wrapping_quotes(trim_spaces(parts.rest))))
+		}
+
+	{ href: String.str_from_utf8(parts.first), title }
+}
+
+lookup_reference : List(ReferenceDefinition), Str -> Try(Markdown.LinkTarget, [NotFound])
+lookup_reference = |refs, label| {
+	match refs {
+		[] =>
+			Err(NotFound)
+
+		[ref, ..] if ref.label == label =>
+			Ok(ref.target)
+
+		[_, .. as rest] =>
+			lookup_reference(rest, label)
+	}
+}
+
+flush_text : String.Utf8, List(Markdown.Inline) -> List(Markdown.Inline)
 flush_text = |text, nodes| {
 	if text.is_empty() {
 		nodes
@@ -746,6 +1477,21 @@ find_unescaped_sequence = |input, needle| {
 	find_unescaped_sequence_help(input, needle, [])
 }
 
+find_sequence_help : String.Utf8, String.Utf8, String.Utf8 -> Try({ before : String.Utf8, after : String.Utf8 }, [NotFound])
+find_sequence_help = |input, needle, acc| {
+	if starts_with_bytes(input, needle) {
+		Ok({ before: acc, after: input.drop_first(needle.len()) })
+	} else {
+		match input {
+			[] =>
+				Err(NotFound)
+
+			[first, .. as rest] =>
+				find_sequence_help(rest, needle, acc.append(first))
+		}
+	}
+}
+
 find_unescaped_sequence_help : String.Utf8, String.Utf8, String.Utf8 -> Try({ before : String.Utf8, after : String.Utf8 }, [NotFound])
 find_unescaped_sequence_help = |input, needle, acc| {
 	if starts_with_bytes(input, needle) {
@@ -762,27 +1508,6 @@ find_unescaped_sequence_help = |input, needle, acc| {
 				find_unescaped_sequence_help(rest, needle, acc.append(first))
 		}
 	}
-}
-
-find_sequence_help : String.Utf8, String.Utf8, String.Utf8 -> Try({ before : String.Utf8, after : String.Utf8 }, [NotFound])
-find_sequence_help = |input, needle, acc| {
-	if starts_with_bytes(input, needle) {
-		Ok({ before: acc, after: input.drop_first(needle.len()) })
-	} else {
-		match input {
-			[] =>
-				Err(NotFound)
-
-			[first, .. as rest] =>
-				find_sequence_help(rest, needle, acc.append(first))
-		}
-	}
-}
-
-starts_with_bytes : String.Utf8, String.Utf8 -> Bool
-starts_with_bytes = |input, prefix| {
-	{ before: start, others: _ } = input.split_at(prefix.len())
-	start == prefix
 }
 
 split_lines : String.Utf8 -> List(Line)
@@ -807,20 +1532,20 @@ split_lines_help = |input, current, lines| {
 	}
 }
 
-line_indent : Line -> U64
-line_indent = |line| {
-	count_leading_spaces(line.raw, 0)
-}
-
-count_leading_spaces : String.Utf8, U64 -> U64
-count_leading_spaces = |input, count| {
-	match input {
-		[' ', .. as rest] =>
-			count_leading_spaces(rest, count + 1)
+consume_blank_lines : List(Line), Bool -> { input : List(Line), saw_blank : Bool }
+consume_blank_lines = |lines, saw_blank| {
+	match lines {
+		[line, .. as rest] if line_is_blank(line) =>
+			consume_blank_lines(rest, Bool.True)
 
 		_ =>
-			count
+			{ input: lines, saw_blank }
 	}
+}
+
+line_indent : Line -> U64
+line_indent = |line| {
+	count_leading_byte(line.raw, ' ', 0)
 }
 
 strip_indent : Line, U64 -> String.Utf8
@@ -850,6 +1575,33 @@ bytes_are_blank = |bytes| {
 	}
 }
 
+starts_with_bytes : String.Utf8, String.Utf8 -> Bool
+starts_with_bytes = |input, prefix| {
+	{ before: start, others: _ } = input.split_at(prefix.len())
+	start == prefix
+}
+
+ends_with_byte : String.Utf8, U8 -> Bool
+ends_with_byte = |bytes, expected| {
+	ends_with_byte_help(bytes, expected, Err(NotFound))
+}
+
+ends_with_byte_help : String.Utf8, U8, Try(U8, [NotFound]) -> Bool
+ends_with_byte_help = |bytes, expected, last| {
+	match bytes {
+		[] =>
+			last == Ok(expected)
+
+		[first, .. as rest] =>
+			ends_with_byte_help(rest, expected, Ok(first))
+	}
+}
+
+is_exact_bytes : String.Utf8, String.Utf8 -> Bool
+is_exact_bytes = |left, right| {
+	left == right
+}
+
 all_bytes_are : String.Utf8, U8 -> Bool
 all_bytes_are = |bytes, expected| {
 	match bytes {
@@ -859,30 +1611,6 @@ all_bytes_are = |bytes, expected| {
 		[first, .. as rest] =>
 			first == expected and all_bytes_are(rest, expected)
 	}
-}
-
-join_lines_with_spaces : List(String.Utf8) -> String.Utf8
-join_lines_with_spaces = |lines| {
-	join_lines_with_spaces_help(lines, [])
-}
-
-join_lines_with_spaces_help : List(String.Utf8), String.Utf8 -> String.Utf8
-join_lines_with_spaces_help = |lines, acc| {
-	match lines {
-		[] =>
-			acc
-
-		[line, .. as rest] if acc.is_empty() =>
-			join_lines_with_spaces_help(rest, append_bytes(acc, line))
-
-		[line, .. as rest] =>
-			join_lines_with_spaces_help(rest, append_bytes(acc.append(' '), line))
-	}
-}
-
-append_line : String.Utf8, String.Utf8 -> String.Utf8
-append_line = |acc, line| {
-	append_bytes(acc, line).append('\n')
 }
 
 append_bytes : String.Utf8, String.Utf8 -> String.Utf8
@@ -896,8 +1624,311 @@ append_bytes = |left, right| {
 	}
 }
 
-# # temporyary parser for anything that is not yet supported
-# # just parse into a TODO tag for now
+join_lines_with_newlines : List(String.Utf8) -> String.Utf8
+join_lines_with_newlines = |lines| {
+	join_lines_with_newlines_help(lines, [])
+}
+
+join_lines_with_newlines_help : List(String.Utf8), String.Utf8 -> String.Utf8
+join_lines_with_newlines_help = |lines, acc| {
+	match lines {
+		[] =>
+			acc
+
+		[line, .. as rest] =>
+			join_lines_with_newlines_help(rest, append_bytes(acc, line).append('\n'))
+	}
+}
+
+join_inline_lines : List(String.Utf8) -> String.Utf8
+join_inline_lines = |lines| {
+	join_inline_lines_help(lines, [])
+}
+
+join_inline_lines_help : List(String.Utf8), String.Utf8 -> String.Utf8
+join_inline_lines_help = |lines, acc| {
+	match lines {
+		[] =>
+			acc
+
+		[line, .. as rest] if acc.is_empty() =>
+			join_inline_lines_help(rest, append_bytes(acc, line))
+
+		[line, .. as rest] if ends_with_hard_break_marker(acc) =>
+			join_inline_lines_help(rest, append_bytes(acc.append('\n'), line))
+
+		[line, .. as rest] =>
+			join_inline_lines_help(rest, append_bytes(acc.append(' '), line))
+	}
+}
+
+ends_with_hard_break_marker : String.Utf8 -> Bool
+ends_with_hard_break_marker = |bytes| {
+	ends_with_byte(bytes, '\\') or ends_with_two_spaces(bytes)
+}
+
+ends_with_two_spaces : String.Utf8 -> Bool
+ends_with_two_spaces = |bytes| {
+	ends_with_two_spaces_help(bytes, 0)
+}
+
+ends_with_two_spaces_help : String.Utf8, U64 -> Bool
+ends_with_two_spaces_help = |bytes, spaces| {
+	match bytes {
+		[] =>
+			spaces >= 2
+
+		[' ', .. as rest] =>
+			ends_with_two_spaces_help(rest, spaces + 1)
+
+		[_, .. as rest] =>
+			ends_with_two_spaces_help(rest, 0)
+	}
+}
+
+trim_spaces : String.Utf8 -> String.Utf8
+trim_spaces = |bytes| {
+	trim_end_spaces(trim_start_spaces(bytes))
+}
+
+trim_start_spaces : String.Utf8 -> String.Utf8
+trim_start_spaces = |bytes| {
+	match bytes {
+		[' ', .. as rest] =>
+			trim_start_spaces(rest)
+
+		['\t', .. as rest] =>
+			trim_start_spaces(rest)
+
+		_ =>
+			bytes
+	}
+}
+
+trim_end_spaces : String.Utf8 -> String.Utf8
+trim_end_spaces = |bytes| {
+	trim_end_spaces_help(bytes, [], [])
+}
+
+trim_end_spaces_help : String.Utf8, String.Utf8, String.Utf8 -> String.Utf8
+trim_end_spaces_help = |bytes, out, pending_spaces| {
+	match bytes {
+		[] =>
+			out
+
+		[' ', .. as rest] =>
+			trim_end_spaces_help(rest, out, pending_spaces.append(' '))
+
+		['\t', .. as rest] =>
+			trim_end_spaces_help(rest, out, pending_spaces.append('\t'))
+
+		[first, .. as rest] =>
+			trim_end_spaces_help(rest, append_bytes(out, pending_spaces).append(first), [])
+	}
+}
+
+trim_closing_heading_marker : String.Utf8 -> String.Utf8
+trim_closing_heading_marker = |bytes| {
+	trim_closing_heading_marker_help(trim_spaces(bytes), [], [])
+}
+
+trim_closing_heading_marker_help : String.Utf8, String.Utf8, String.Utf8 -> String.Utf8
+trim_closing_heading_marker_help = |bytes, out, pending_hashes| {
+	match bytes {
+		[] if pending_hashes.is_empty() =>
+			out
+
+		[] =>
+			trim_spaces(out)
+
+		['#', .. as rest] =>
+			trim_closing_heading_marker_help(rest, out, pending_hashes.append('#'))
+
+		[first, .. as rest] =>
+			trim_closing_heading_marker_help(rest, append_bytes(out, pending_hashes).append(first), [])
+	}
+}
+
+split_first_space : String.Utf8 -> { first : String.Utf8, rest : String.Utf8 }
+split_first_space = |bytes| {
+	split_first_space_help(bytes, [])
+}
+
+split_first_space_help : String.Utf8, String.Utf8 -> { first : String.Utf8, rest : String.Utf8 }
+split_first_space_help = |bytes, first_part| {
+	match bytes {
+		[] =>
+			{ first: first_part, rest: [] }
+
+		[' ', .. as rest] =>
+			{ first: first_part, rest }
+
+		['\t', .. as rest] =>
+			{ first: first_part, rest }
+
+		[first, .. as rest] =>
+			split_first_space_help(rest, first_part.append(first))
+	}
+}
+
+strip_wrapping_quotes : String.Utf8 -> String.Utf8
+strip_wrapping_quotes = |bytes| {
+	match bytes {
+		['"', .. as rest] => {
+			found = find_sequence(rest, "\"".to_utf8()) ?? { before: rest, after: [] }
+			found.before
+		}
+
+		['\'', .. as rest] => {
+			found = find_sequence(rest, "'".to_utf8()) ?? { before: rest, after: [] }
+			found.before
+		}
+
+		_ =>
+			bytes
+	}
+}
+
+normalize_reference_label : String.Utf8 -> Str
+normalize_reference_label = |label| {
+	String.str_from_utf8(collapse_reference_whitespace(lower_ascii_bytes(trim_spaces(label)), [], Bool.False))
+}
+
+lower_ascii_bytes : String.Utf8 -> String.Utf8
+lower_ascii_bytes = |bytes| {
+	List.from_iter(bytes.iter().map(lower_ascii_byte))
+}
+
+lower_ascii_byte : U8 -> U8
+lower_ascii_byte = |byte| {
+	if byte >= 'A' and byte <= 'Z' {
+		byte + 32
+	} else {
+		byte
+	}
+}
+
+collapse_reference_whitespace : String.Utf8, String.Utf8, Bool -> String.Utf8
+collapse_reference_whitespace = |bytes, out, pending_space| {
+	match bytes {
+		[] =>
+			out
+
+		[first, .. as rest] if first == ' ' or first == '\t' or first == '\n' =>
+			collapse_reference_whitespace(rest, out, Bool.True)
+
+		[first, .. as rest] if pending_space and !out.is_empty() =>
+			collapse_reference_whitespace(rest, out.append(' ').append(first), Bool.False)
+
+		[first, .. as rest] =>
+			collapse_reference_whitespace(rest, out.append(first), Bool.False)
+	}
+}
+
+count_leading_byte : String.Utf8, U8, U64 -> U64
+count_leading_byte = |bytes, expected, count| {
+	match bytes {
+		[first, .. as rest] if first == expected =>
+			count_leading_byte(rest, expected, count + 1)
+
+		_ =>
+			count
+	}
+}
+
+count_byte : String.Utf8, U8 -> U64
+count_byte = |bytes, expected| {
+	count_byte_help(bytes, expected, 0)
+}
+
+count_byte_help : String.Utf8, U8, U64 -> U64
+count_byte_help = |bytes, expected, count| {
+	match bytes {
+		[] =>
+			count
+
+		[first, .. as rest] if first == expected =>
+			count_byte_help(rest, expected, count + 1)
+
+		[_, .. as rest] =>
+			count_byte_help(rest, expected, count)
+	}
+}
+
+first_non_space : String.Utf8 -> Try(U8, [NotFound])
+first_non_space = |bytes| {
+	match bytes {
+		[] =>
+			Err(NotFound)
+
+		[' ', .. as rest] =>
+			first_non_space(rest)
+
+		[first, ..] =>
+			Ok(first)
+	}
+}
+
+digits_to_u64 : String.Utf8 -> U64
+digits_to_u64 = |digits| {
+	digits.fold(
+		0,
+		|sum, digit| {
+			sum * 10 + (digit - '0').to_u64()
+		},
+	)
+}
+
+is_digit_byte : U8 -> Bool
+is_digit_byte = |byte| {
+	byte >= '0' and byte <= '9'
+}
+
+is_alphabetic_byte : U8 -> Bool
+is_alphabetic_byte = |byte| {
+	(byte >= 'a' and byte <= 'z') or (byte >= 'A' and byte <= 'Z')
+}
+
+is_email_bytes : String.Utf8 -> Bool
+is_email_bytes = |bytes| {
+	contains_byte(bytes, '@') and contains_byte(bytes, '.')
+}
+
+contains_byte : String.Utf8, U8 -> Bool
+contains_byte = |bytes, expected| {
+	match bytes {
+		[] =>
+			Bool.False
+
+		[first, ..] if first == expected =>
+			Bool.True
+
+		[_, .. as rest] =>
+			contains_byte(rest, expected)
+	}
+}
+
+is_escapable_inline_byte : U8 -> Bool
+is_escapable_inline_byte = |byte| {
+	byte == '\\'
+		or byte == '*'
+		or byte == '_'
+		or byte == '`'
+		or byte == '['
+		or byte == ']'
+		or byte == '('
+		or byte == ')'
+		or byte == '!'
+		or byte == '~'
+		or byte == '|'
+}
+
+end_of_line = Parser.one_of([String.string("\n"), String.string("\r\n")])
+
+not_end_of_line = |b| {
+	b != '\n' and b != '\r'
+}
+
 todo : Parser(String.Utf8, Markdown)
 todo =
 	Parser.const(|s| TODO(s))
@@ -909,147 +1940,31 @@ expect {
 	a == TODO("Foo Bar")
 }
 
-## Multiple markdown lines parse into paragraph nodes and blank lines separate blocks.
+## Hash-prefixed headings parse with inline content.
 expect {
-	a = String.parse_str(Markdown.all, "Foo Bar\n\nBaz")?
-	a == [Paragraph([Text("Foo Bar")]), Paragraph([Text("Baz")])]
-}
-
-end_of_line = Parser.one_of([String.string("\n"), String.string("\r\n")])
-
-not_end_of_line = |b| {
-	b != '\n' and b != '\r'
-}
-
-## Hash-prefixed headings parse with their heading level.
-expect {
-	a = String.parse_str(Markdown.heading, "# Foo Bar")?
-	a == Heading(One, [Text("Foo Bar")])
+	a = String.parse_str(Markdown.heading, "# Foo **Bar** #")?
+	a == Heading({ level: One, content: [Text("Foo "), Strong([Text("Bar")])] })
 }
 
 ## Underlined headings parse as level two headings.
 expect {
 	a = String.parse_str(Markdown.heading, "Foo Bar\n---")?
-	a == Heading(Two, [Text("Foo Bar")])
+	a == Heading({ level: Two, content: [Text("Foo Bar")] })
 }
 
-inline_heading =
-	Parser.const(
-		|level| {
-			|str| {
-				Heading(level, parse_inlines(str.to_utf8()))
-			}
-		},
-	)
-		.keep(
-			Parser.one_of(
-				[
-					Parser.const(One).skip(String.string("# ")),
-					Parser.const(Two).skip(String.string("## ")),
-					Parser.const(Three).skip(String.string("### ")),
-					Parser.const(Four).skip(String.string("#### ")),
-					Parser.const(Five).skip(String.string("##### ")),
-					Parser.const(Six).skip(String.string("###### ")),
-				],
-			),
-		)
-		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
-
-## Inline headings capture the heading text after the marker.
+## Markdown links parse as inline link nodes.
 expect {
-	a = String.parse_str(inline_heading, "# Foo Bar")?
-	a == Heading(One, [Text("Foo Bar")])
+	a = String.parse_str(Markdown.link, "[roc](https://roc-lang.org \"Roc\")")?
+	a == Link({ label: [Text("roc")], target: { href: "https://roc-lang.org", title: Some("Roc") } })
 }
 
-## Inline heading partial parsing leaves the following line untouched.
-expect {
-	a = String.parse_str_partial(inline_heading, "### Foo Bar\nBaz")?
-	a == { val: Heading(Three, [Text("Foo Bar")]), input: "\nBaz" }
-}
-
-two_line_heading_level_one =
-	Parser.const(
-		|str| {
-			Heading(One, parse_inlines(str.to_utf8()))
-		},
-	)
-		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
-		.skip(end_of_line)
-		.skip(String.string("=="))
-		.skip(
-			Parser.chomp_while(
-				|b| {
-					not_end_of_line(b) and b == '='
-				},
-			),
-		)
-
-## Equal-sign underlines parse as level one headings.
-expect {
-	a = String.parse_str(two_line_heading_level_one, "Foo Bar\n==")?
-	a == Heading(One, [Text("Foo Bar")])
-}
-
-## Level one heading partial parsing leaves the trailing newline.
-expect {
-	a = String.parse_str_partial(two_line_heading_level_one, "Foo Bar\n=============\n")?
-	a == { val: Heading(One, [Text("Foo Bar")]), input: "\n" }
-}
-
-two_line_heading_level_two =
-	Parser.const(
-		|str| {
-			Heading(Two, parse_inlines(str.to_utf8()))
-		},
-	)
-		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
-		.skip(end_of_line)
-		.skip(String.string("--"))
-		.skip(
-			Parser.chomp_while(
-				|b| {
-					not_end_of_line(b) and b == '-'
-				},
-			),
-		)
-
-## Dash underlines parse as level two headings.
-expect {
-	a = String.parse_str(two_line_heading_level_two, "Foo Bar\n---")?
-	a == Heading(Two, [Text("Foo Bar")])
-}
-
-## Level two heading partial parsing leaves the following line.
-expect {
-	a = String.parse_str_partial(two_line_heading_level_two, "Foo Bar\n-----\nApples")?
-	a == { val: Heading(Two, [Text("Foo Bar")]), input: "\nApples" }
-}
-
-## Markdown links capture their label and target URL.
-expect {
-	a = String.parse_str(Markdown.link, "[roc](https://roc-lang.org)")?
-	a == Link({ alt: "roc", href: "https://roc-lang.org" })
-}
-
-## Link partial parsing leaves the next line untouched.
-expect {
-	a = String.parse_str_partial(Markdown.link, "[roc](https://roc-lang.org)\nApples")?
-	a == { val: Link({ alt: "roc", href: "https://roc-lang.org" }), input: "\nApples" }
-}
-
-## Markdown images capture their alt text and source URL.
+## Markdown images parse as inline image nodes.
 expect {
 	a = String.parse_str(Markdown.image, "![alt text](/images/logo.png)")?
-	a == Image({ alt: "alt text", href: "/images/logo.png" })
+	a == Image({ alt: [Text("alt text")], target: { href: "/images/logo.png", title: None } })
 }
 
-## Image partial parsing leaves the next line untouched.
-expect {
-	a = String.parse_str_partial(Markdown.image, "![alt text](/images/logo.png)\nApples")?
-	a == { val: Image({ alt: "alt text", href: "/images/logo.png" }), input: "\nApples" }
-}
-
-## Code blocks capture their extension and body text.
+## Code blocks capture their info string and body text.
 expect {
 	text =
 		\\```roc
@@ -1058,12 +1973,12 @@ expect {
 		\\```
 
 	a = String.parse_str(Markdown.code, text)?
-	a == Code({ ext: "roc", pre: "# some code\nfoo = bar\n" })
+	a == Code({ info: "roc", pre: "# some code\nfoo = bar\n" })
 }
 
-## Public inline parser parses text, emphasis, strong, code, and prose links.
+## Public inline parser parses emphasis, strong, strikethrough, code, and links.
 expect {
-	actual = String.parse_str(Markdown.inlines, "Intro with **bold**, *em*, _also em_, `code`, and [a link](https://example.com).")?
+	actual = String.parse_str(Markdown.inlines, "Intro with **bold**, *em*, ~~gone~~, `code`, and [a link](https://example.com).")?
 
 	actual
 		== [
@@ -1072,95 +1987,281 @@ expect {
 			Text(", "),
 			Emphasis([Text("em")]),
 			Text(", "),
-			Emphasis([Text("also em")]),
+			Strikethrough([Text("gone")]),
 			Text(", "),
 			InlineCode("code"),
 			Text(", and "),
-			InlineLink({ alt: [Text("a link")], href: "https://example.com" }),
+			Link({ label: [Text("a link")], target: { href: "https://example.com", title: None } }),
 			Text("."),
 		]
 }
 
 ## Escaped inline delimiters parse as literal text.
 expect {
-	text = "\\*literal\\*, \\_em\\_, \\`code\\`, and \\[a link](https://example.com)"
+	text = "\\*literal\\*, \\_em\\_, \\`code\\`, and \\[a link](target)"
 
 	actual = String.parse_str(Markdown.inlines, text)?
 
-	actual == [Text("*literal*, _em_, `code`, and [a link](https://example.com)")]
+	actual == [Text("*literal*, _em_, `code`, and [a link](target)")]
 }
 
-## Heading text can contain inline spans.
+## Inline images parse inside prose.
 expect {
-	actual = String.parse_str(Markdown.heading, "# Title with **strong** text")?
+	actual = String.parse_str(Markdown.inlines, "Logo ![Roc](/roc.png) here")?
 
 	actual
-		== Heading(
-			One,
-			[
-				Text("Title with "),
-				Strong([Text("strong")]),
-				Text(" text"),
-			],
-		)
+		== [
+			Text("Logo "),
+			Image({ alt: [Text("Roc")], target: { href: "/roc.png", title: None } }),
+			Text(" here"),
+		]
 }
 
-## Standalone links in documents parse as paragraph inline links.
+## Autolinks and bare URLs parse as inline links.
 expect {
-	actual = String.parse_str(Markdown.all, "[roc](https://roc-lang.org)")?
+	actual = String.parse_str(Markdown.inlines, "<https://example.com> and www.example.com")?
+
+	actual
+		== [
+			Link({ label: [Text("https://example.com")], target: { href: "https://example.com", title: None } }),
+			Text(" and "),
+			Link({ label: [Text("www.example.com")], target: { href: "www.example.com", title: None } }),
+		]
+}
+
+## Hard line breaks parse from trailing spaces and backslash newlines.
+expect {
+	actual = String.parse_str(Markdown.inlines, "one  \ntwo\\\nthree")?
+
+	actual == [Text("one"), HardBreak, Text("two"), HardBreak, Text("three")]
+}
+
+## Raw HTML inline spans are preserved.
+expect {
+	actual = String.parse_str(Markdown.inlines, "Hello <span>world</span>")?
+
+	actual == [Text("Hello "), HtmlInline("<span>"), Text("world"), HtmlInline("</span>")]
+}
+
+## Reference links resolve using definitions and definitions are omitted from blocks.
+expect {
+	text =
+		\\[roc]: https://roc-lang.org "Roc"
+		\\Read [Roc][roc].
+
+	actual = String.parse_str(Markdown.all, text)?
 
 	actual
 		== [
 			Paragraph(
 				[
-					InlineLink({ alt: [Text("roc")], href: "https://roc-lang.org" }),
+					Text("Read "),
+					Link({ label: [Text("Roc")], target: { href: "https://roc-lang.org", title: Some("Roc") } }),
+					Text("."),
 				],
 			),
 		]
 }
 
-## Horizontal rules parse as block nodes.
+## Unresolved references remain literal text.
 expect {
-	actual = String.parse_str(Markdown.all, "---")?
+	actual = String.parse_str(Markdown.all, "Read [Roc][missing].")?
 
-	actual == [HorizontalRule]
+	actual == [Paragraph([Text("Read [Roc][missing].")])]
 }
 
-## Ordered list items parse into ordered list blocks.
+## Frontmatter is preserved only at the start of a document.
 expect {
 	text =
-		\\1. One
-		\\2. Two
+		\\---
+		\\title: Hello
+		\\---
+		\\Body
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual == [Frontmatter({ raw: "title: Hello\n" }), Paragraph([Text("Body")])]
+}
+
+## Standalone thematic breaks parse as block nodes.
+expect {
+	actual = String.parse_str(Markdown.all, "- - -")?
+
+	actual == [ThematicBreak]
+}
+
+## Ordered lists preserve their starting number and task list state.
+expect {
+	text =
+		\\3) [x] Done
+		\\4) [ ] Later
 
 	actual = String.parse_str(Markdown.all, text)?
 
 	actual
 		== [
-			OrderedList(
-				[
-					ListItem([Text("One")], []),
-					ListItem([Text("Two")], []),
-				],
+			ListBlock(
+				{
+					kind: Ordered({ start: 3 }),
+					loose: Bool.False,
+					items: [
+						{ task: Checked, blocks: [Paragraph([Text("Done")])] },
+						{ task: Unchecked, blocks: [Paragraph([Text("Later")])] },
+					],
+				},
 			),
 		]
 }
 
-## Indented list continuation lines are folded into the item text.
+## Unordered marker variants parse into one unordered list.
 expect {
 	text =
-		\\- first line
-		\\  continued line
+		\\* One
+		\\+ Two
 
 	actual = String.parse_str(Markdown.all, text)?
 
 	actual
 		== [
-			UnorderedList(
-				[
-					ListItem([Text("first line continued line")], []),
-				],
+			ListBlock(
+				{
+					kind: Unordered,
+					loose: Bool.False,
+					items: [
+						{ task: NoTask, blocks: [Paragraph([Text("One")])] },
+						{ task: NoTask, blocks: [Paragraph([Text("Two")])] },
+					],
+				},
 			),
 		]
+}
+
+## Blank lines inside lists mark the list as loose.
+expect {
+	text =
+		\\- One
+		\\
+		\\- Two
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual
+		== [
+			ListBlock(
+				{
+					kind: Unordered,
+					loose: Bool.True,
+					items: [
+						{ task: NoTask, blocks: [Paragraph([Text("One")])] },
+						{ task: NoTask, blocks: [Paragraph([Text("Two")])] },
+					],
+				},
+			),
+		]
+}
+
+## Nested unordered lists parse as child blocks.
+expect {
+	text =
+		\\- One
+		\\  - Nested
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual
+		== [
+			ListBlock(
+				{
+					kind: Unordered,
+					loose: Bool.False,
+					items: [
+						{
+							task: NoTask,
+							blocks: [
+								Paragraph([Text("One")]),
+								ListBlock(
+									{
+										kind: Unordered,
+										loose: Bool.False,
+										items: [
+											{ task: NoTask, blocks: [Paragraph([Text("Nested")])] },
+										],
+									},
+								),
+							],
+						},
+					],
+				},
+			),
+		]
+}
+
+## Tilde fenced code blocks parse with info strings.
+expect {
+	text =
+		\\~~~roc
+		\\main = 1
+		\\~~~
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual == [Code({ info: "roc", pre: "main = 1\n" })]
+}
+
+## Indented code blocks parse from four leading spaces.
+expect {
+	actual = String.parse_str(Markdown.all, "    main = 1")?
+
+	actual == [Code({ info: "", pre: "main = 1\n" })]
+}
+
+## Pipe tables parse header alignment and inline cell content.
+expect {
+	text =
+		\\| Name | Count |
+		\\| :--- | ---: |
+		\\| **Roc** | `1|2` |
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual
+		== [
+			Table(
+				{
+					header: [[Text("Name")], [Text("Count")]],
+					align: [Left, Right],
+					rows: [
+						[
+							[Strong([Text("Roc")])],
+							[InlineCode("1|2")],
+						],
+					],
+				},
+			),
+		]
+}
+
+## Malformed tables remain paragraph text.
+expect {
+	text =
+		\\Name | Count
+		\\not a delimiter
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual == [Paragraph([Text("Name | Count not a delimiter")])]
+}
+
+## Raw HTML blocks are preserved without validation.
+expect {
+	text =
+		\\<section>
+		\\raw
+		\\</section>
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual == [HtmlBlock("<section>\nraw\n</section>\n")]
 }
 
 ## Unclosed fenced code blocks fail document parsing.
@@ -1175,7 +2276,10 @@ expect {
 ## Article body markdown parses into structured blocks without TODO fallbacks.
 expect {
 	text =
-		\\# Title
+		\\---
+		\\title: Article
+		\\---
+		\\# Title with **style**
 		\\
 		\\Intro with **bold**, `code`, and [a link](https://example.com).
 		\\
@@ -1194,7 +2298,8 @@ expect {
 
 	actual
 		== [
-			Heading(One, [Text("Title")]),
+			Frontmatter({ raw: "title: Article\n" }),
+			Heading({ level: One, content: [Text("Title with "), Strong([Text("style")])] }),
 			Paragraph(
 				[
 					Text("Intro with "),
@@ -1202,25 +2307,34 @@ expect {
 					Text(", "),
 					InlineCode("code"),
 					Text(", and "),
-					InlineLink({ alt: [Text("a link")], href: "https://example.com" }),
+					Link({ label: [Text("a link")], target: { href: "https://example.com", title: None } }),
 					Text("."),
 				],
 			),
-			Image({ alt: "alt text", href: "/image.png" }),
-			Code({ ext: "roc", pre: "main = 1\n" }),
-			UnorderedList(
-				[
-					ListItem(
-						[Text("One")],
-						[
-							UnorderedList(
-								[
-									ListItem([Text("Nested")], []),
-								],
-							),
-						],
-					),
-				],
+			Paragraph([Image({ alt: [Text("alt text")], target: { href: "/image.png", title: None } })]),
+			Code({ info: "roc", pre: "main = 1\n" }),
+			ListBlock(
+				{
+					kind: Unordered,
+					loose: Bool.False,
+					items: [
+						{
+							task: NoTask,
+							blocks: [
+								Paragraph([Text("One")]),
+								ListBlock(
+									{
+										kind: Unordered,
+										loose: Bool.False,
+										items: [
+											{ task: NoTask, blocks: [Paragraph([Text("Nested")])] },
+										],
+									},
+								),
+							],
+						},
+					],
+				},
 			),
 			Blockquote(
 				[

--- a/package/Markdown.roc
+++ b/package/Markdown.roc
@@ -4,6 +4,10 @@ import String
 # # Content values
 Markdown := [
 	Heading(Level, Str),
+	Paragraph(List(Inline)),
+	Blockquote(List(Markdown)),
+	UnorderedList(List(Markdown)),
+	ListItem(List(Inline), List(Markdown)),
 	Link({ alt : Str, href : Str }),
 	Image({ alt : Str, href : Str }),
 	Code({ ext : Str, pre : Str }),
@@ -11,18 +15,16 @@ Markdown := [
 ].{
 	Level : [One, Two, Three, Four, Five, Six]
 
+	Inline := [
+		Text(Str),
+		Strong(List(Inline)),
+		Emphasis(List(Inline)),
+		InlineCode(Str),
+		InlineLink({ alt : List(Inline), href : Str }),
+	]
+
 	all : Parser(String.Utf8, List(Markdown))
-	all = 
-		Parser.one_of(
-			[
-				heading,
-				link,
-				image,
-				code,
-				todo,
-			],
-		)
-			.sep_by(end_of_line)
+	all = parse_all
 
 	## Headings
 	##
@@ -31,7 +33,7 @@ Markdown := [
 	## expect String.parse_str(heading, "Foo Bar\n---") == Ok(Heading(Two, "Foo Bar"))
 	## ```
 	heading : Parser(String.Utf8, Markdown)
-	heading = 
+	heading =
 		Parser.one_of(
 			[
 				inline_heading,
@@ -43,10 +45,10 @@ Markdown := [
 	## Links
 	##
 	## ```roc
-	## expect String.parse_str(link, "[roc](https://roc-lang.org)") == Ok(Link("roc", "https://roc-lang.org"))
+	## expect String.parse_str(link, "[roc](https://roc-lang.org)") == Ok(Link({ alt: "roc", href: "https://roc-lang.org" }))
 	## ```
 	link : Parser(String.Utf8, Markdown)
-	link = 
+	link =
 		Parser.const(
 			|alt| {
 				|href| {
@@ -75,10 +77,10 @@ Markdown := [
 	## Images
 	##
 	## ```roc
-	## expect String.parse_str(image, "![alt text](/images/logo.png)") == Ok(Image("alt text", "/images/logo.png"))
+	## expect String.parse_str(image, "![alt text](/images/logo.png)") == Ok(Image({ alt: "alt text", href: "/images/logo.png" }))
 	## ```
 	image : Parser(String.Utf8, Markdown)
-	image = 
+	image =
 		Parser.const(
 			|alt| {
 				|href| {
@@ -120,7 +122,7 @@ Markdown := [
 	## }
 	## ```
 	code : Parser(String.Utf8, Markdown)
-	code = 
+	code =
 		Parser.const(|ext| |pre| Code({ ext, pre }))
 			.keep(
 				Parser.one_of(
@@ -140,23 +142,613 @@ Markdown := [
 			.keep(chomp_until_code_block_end)
 }
 
+Line : { raw : String.Utf8 }
+
+parse_all : Parser(String.Utf8, List(Markdown))
+parse_all =
+	Parser.build_primitive_parser(
+		|input| {
+			lines = split_lines(input)
+			parsed = parse_blocks_from_lines(lines, 0)?
+
+			match parsed.input {
+				[] =>
+					Ok({ val: parsed.val, input: [] })
+
+				_ =>
+					Err(ParsingFailure("unexpected unparsed markdown lines"))
+			}
+		},
+	)
+
+parse_blocks_from_lines : List(Line), U64 -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
+parse_blocks_from_lines = |lines, min_indent| {
+	parse_blocks_help(lines, min_indent, [])
+}
+
+parse_blocks_help : List(Line), U64, List(Markdown) -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
+parse_blocks_help = |lines, min_indent, blocks| {
+	match lines {
+		[] =>
+			Ok({ val: blocks, input: [] })
+
+		[line, .. as rest] if line_is_blank(line) =>
+			parse_blocks_help(rest, min_indent, blocks)
+
+		[line, ..] if line_indent(line) < min_indent =>
+			Ok({ val: blocks, input: lines })
+
+		_ => {
+			parsed = parse_one_block(lines, min_indent)?
+			parse_blocks_help(parsed.input, min_indent, blocks.append(parsed.val))
+		}
+	}
+}
+
+parse_one_block : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_one_block = |lines, min_indent| {
+	match lines {
+		[line, underline, .. as rest_after_heading] if can_be_setext_heading_text(line, min_indent) => {
+			match underline_level(underline, min_indent) {
+				Ok(level) =>
+					Ok({ val: Heading(level, String.str_from_utf8(strip_indent(line, min_indent))), input: rest_after_heading })
+
+				Err(_) =>
+					parse_one_block_without_setext(lines, min_indent)
+			}
+		}
+
+		_ =>
+			parse_one_block_without_setext(lines, min_indent)
+	}
+}
+
+parse_one_block_without_setext : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_one_block_without_setext = |lines, min_indent| {
+	match lines {
+		[] =>
+			Err(ParsingFailure("expected a markdown block"))
+
+		[line, .. as rest] => {
+			content = strip_indent(line, min_indent)
+
+			match parse_hash_heading_line(content) {
+				Ok(block) =>
+					Ok({ val: block, input: rest })
+
+				Err(_) if is_code_fence_line(line, min_indent) =>
+					parse_code_block(lines, min_indent)
+
+				Err(_) => {
+					match parse_image_line(content) {
+						Ok(block) =>
+							Ok({ val: block, input: rest })
+
+						Err(_) => {
+							match parse_link_line(content) {
+								Ok(block) =>
+									Ok({ val: block, input: rest })
+
+								Err(_) if is_blockquote_line(line, min_indent) =>
+									parse_blockquote(lines, min_indent)
+
+								Err(_) if is_list_item_line(line, min_indent) =>
+									parse_unordered_list(lines, min_indent)
+
+								Err(_) =>
+									parse_paragraph(lines, min_indent)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+parse_paragraph : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_paragraph = |lines, min_indent| {
+	collected = collect_paragraph_lines(lines, min_indent, [])
+
+	if collected.val.is_empty() {
+		Err(ParsingFailure("expected a paragraph line"))
+	} else {
+		text = join_lines_with_spaces(collected.val)
+		Ok({ val: Paragraph(parse_inlines(text)), input: collected.input })
+	}
+}
+
+collect_paragraph_lines : List(Line), U64, List(String.Utf8) -> { val : List(String.Utf8), input : List(Line) }
+collect_paragraph_lines = |lines, min_indent, acc| {
+	match lines {
+		[] =>
+			{ val: acc, input: [] }
+
+		[line, ..] if line_is_blank(line) =>
+			{ val: acc, input: lines }
+
+		[line, ..] if line_indent(line) < min_indent =>
+			{ val: acc, input: lines }
+
+		[line, ..] if is_block_start(line, min_indent) =>
+			{ val: acc, input: lines }
+
+		[line, .. as rest] =>
+			collect_paragraph_lines(rest, min_indent, acc.append(strip_indent(line, min_indent)))
+	}
+}
+
+parse_code_block : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_code_block = |lines, min_indent| {
+	match lines {
+		[line, .. as rest] => {
+			fence = strip_indent(line, min_indent)
+			ext = String.str_from_utf8(fence.drop_first(3))
+			code = collect_code_lines(rest, min_indent, [])?
+
+			Ok({ val: Code({ ext, pre: String.str_from_utf8(code.val) }), input: code.input })
+		}
+
+		[] =>
+			Err(ParsingFailure("expected a code fence"))
+	}
+}
+
+collect_code_lines : List(Line), U64, String.Utf8 -> Try({ val : String.Utf8, input : List(Line) }, [ParsingFailure(Str)])
+collect_code_lines = |lines, min_indent, pre| {
+	match lines {
+		[] =>
+			Err(ParsingFailure("expected closing ```"))
+
+		[line, .. as rest] if is_code_fence_line(line, min_indent) =>
+			Ok({ val: pre, input: rest })
+
+		[line, .. as rest] => {
+			body_line = 
+				if line_indent(line) >= min_indent {
+					strip_indent(line, min_indent)
+				} else {
+					line.raw
+				}
+
+			collect_code_lines(rest, min_indent, append_line(pre, body_line))
+		}
+	}
+}
+
+parse_blockquote : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_blockquote = |lines, min_indent| {
+	quoted = collect_blockquote_lines(lines, min_indent, [])
+	inner = parse_blocks_from_lines(quoted.val, 0)?
+
+	Ok({ val: Blockquote(inner.val), input: quoted.input })
+}
+
+collect_blockquote_lines : List(Line), U64, List(Line) -> { val : List(Line), input : List(Line) }
+collect_blockquote_lines = |lines, min_indent, acc| {
+	match lines {
+		[] =>
+			{ val: acc, input: [] }
+
+		[line, .. as rest] if is_blockquote_line(line, min_indent) => {
+			content = strip_blockquote_marker(line, min_indent)
+			collect_blockquote_lines(rest, min_indent, acc.append({ raw: content }))
+		}
+
+		_ =>
+			{ val: acc, input: lines }
+	}
+}
+
+parse_unordered_list : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_unordered_list = |lines, min_indent| {
+	parsed = parse_list_items(lines, min_indent, [])?
+	Ok({ val: UnorderedList(parsed.val), input: parsed.input })
+}
+
+parse_list_items : List(Line), U64, List(Markdown) -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
+parse_list_items = |lines, min_indent, items| {
+	match lines {
+		[line, .. as rest] if is_list_item_line(line, min_indent) => {
+			content = strip_indent(line, min_indent).drop_first(2)
+			children = parse_blocks_from_lines(rest, min_indent + 2)?
+			item = ListItem(parse_inlines(content), children.val)
+
+			parse_list_items(children.input, min_indent, items.append(item))
+		}
+
+		_ =>
+			Ok({ val: items, input: lines })
+	}
+}
+
+is_block_start : Line, U64 -> Bool
+is_block_start = |line, min_indent| {
+	if line_indent(line) < min_indent {
+		Bool.False
+	} else {
+		content = strip_indent(line, min_indent)
+
+		is_hash_heading_line(content)
+			or is_code_fence_line(line, min_indent)
+			or parse_image_line(content).is_ok()
+			or parse_link_line(content).is_ok()
+			or is_blockquote_line(line, min_indent)
+			or is_list_item_line(line, min_indent)
+	}
+}
+
+can_be_setext_heading_text : Line, U64 -> Bool
+can_be_setext_heading_text = |line, min_indent| {
+	(!line_is_blank(line)) and line_indent(line) >= min_indent and !is_block_start(line, min_indent)
+}
+
+underline_level : Line, U64 -> Try(Level, [NotFound])
+underline_level = |line, min_indent| {
+	if line_indent(line) != min_indent {
+		Err(NotFound)
+	} else {
+		content = strip_indent(line, min_indent)
+
+		match content {
+			['=', '=', .. as rest] if all_bytes_are(rest, '=') =>
+				Ok(One)
+
+			['-', '-', .. as rest] if all_bytes_are(rest, '-') =>
+				Ok(Two)
+
+			_ =>
+				Err(NotFound)
+		}
+	}
+}
+
+parse_hash_heading_line : String.Utf8 -> Try(Markdown, [NotFound])
+parse_hash_heading_line = |content| {
+	match content {
+		['#', ' ', .. as text] =>
+			Ok(Heading(One, String.str_from_utf8(text)))
+
+		['#', '#', ' ', .. as text] =>
+			Ok(Heading(Two, String.str_from_utf8(text)))
+
+		['#', '#', '#', ' ', .. as text] =>
+			Ok(Heading(Three, String.str_from_utf8(text)))
+
+		['#', '#', '#', '#', ' ', .. as text] =>
+			Ok(Heading(Four, String.str_from_utf8(text)))
+
+		['#', '#', '#', '#', '#', ' ', .. as text] =>
+			Ok(Heading(Five, String.str_from_utf8(text)))
+
+		['#', '#', '#', '#', '#', '#', ' ', .. as text] =>
+			Ok(Heading(Six, String.str_from_utf8(text)))
+
+		_ =>
+			Err(NotFound)
+	}
+}
+
+is_hash_heading_line : String.Utf8 -> Bool
+is_hash_heading_line = |content| {
+	parse_hash_heading_line(content).is_ok()
+}
+
+parse_image_line : String.Utf8 -> Try(Markdown, [NotFound])
+parse_image_line = |content| {
+	match content {
+		['!', '[', .. as rest] => {
+			label = find_sequence(rest, "](".to_utf8())?
+			href = find_sequence(label.after, ")".to_utf8())?
+
+			if href.after.is_empty() {
+				Ok(Image({ alt: String.str_from_utf8(label.before), href: String.str_from_utf8(href.before) }))
+			} else {
+				Err(NotFound)
+			}
+		}
+
+		_ =>
+			Err(NotFound)
+	}
+}
+
+parse_link_line : String.Utf8 -> Try(Markdown, [NotFound])
+parse_link_line = |content| {
+	match content {
+		['[', .. as rest] => {
+			label = find_sequence(rest, "](".to_utf8())?
+			href = find_sequence(label.after, ")".to_utf8())?
+
+			if href.after.is_empty() {
+				Ok(Link({ alt: String.str_from_utf8(label.before), href: String.str_from_utf8(href.before) }))
+			} else {
+				Err(NotFound)
+			}
+		}
+
+		_ =>
+			Err(NotFound)
+	}
+}
+
+is_code_fence_line : Line, U64 -> Bool
+is_code_fence_line = |line, min_indent| {
+	line_indent(line) >= min_indent and starts_with_bytes(strip_indent(line, min_indent), "```".to_utf8())
+}
+
+is_blockquote_line : Line, U64 -> Bool
+is_blockquote_line = |line, min_indent| {
+	line_indent(line) >= min_indent and starts_with_bytes(strip_indent(line, min_indent), ">".to_utf8())
+}
+
+strip_blockquote_marker : Line, U64 -> String.Utf8
+strip_blockquote_marker = |line, min_indent| {
+	content = strip_indent(line, min_indent).drop_first(1)
+
+	match content {
+		[' ', .. as rest] =>
+			rest
+
+		_ =>
+			content
+	}
+}
+
+is_list_item_line : Line, U64 -> Bool
+is_list_item_line = |line, min_indent| {
+	line_indent(line) == min_indent and starts_with_bytes(strip_indent(line, min_indent), "- ".to_utf8())
+}
+
+parse_inlines : String.Utf8 -> List(Inline)
+parse_inlines = |input| {
+	parse_inlines_help(input, [], [])
+}
+
+parse_inlines_help : String.Utf8, String.Utf8, List(Inline) -> List(Inline)
+parse_inlines_help = |input, text, nodes| {
+	match input {
+		[] =>
+			flush_text(text, nodes)
+
+		['*', '*', .. as rest] => {
+			match find_sequence(rest, "**".to_utf8()) {
+				Ok(found) => {
+					next_nodes = flush_text(text, nodes).append(Strong(parse_inlines(found.before)))
+					parse_inlines_help(found.after, [], next_nodes)
+				}
+
+				Err(_) =>
+					parse_inlines_help(rest, text.append('*').append('*'), nodes)
+			}
+		}
+
+		['*', .. as rest] => {
+			match find_sequence(rest, "*".to_utf8()) {
+				Ok(found) => {
+					next_nodes = flush_text(text, nodes).append(Emphasis(parse_inlines(found.before)))
+					parse_inlines_help(found.after, [], next_nodes)
+				}
+
+				Err(_) =>
+					parse_inlines_help(rest, text.append('*'), nodes)
+			}
+		}
+
+		['_', .. as rest] => {
+			match find_sequence(rest, "_".to_utf8()) {
+				Ok(found) => {
+					next_nodes = flush_text(text, nodes).append(Emphasis(parse_inlines(found.before)))
+					parse_inlines_help(found.after, [], next_nodes)
+				}
+
+				Err(_) =>
+					parse_inlines_help(rest, text.append('_'), nodes)
+			}
+		}
+
+		['`', .. as rest] => {
+			match find_sequence(rest, "`".to_utf8()) {
+				Ok(found) => {
+					next_nodes = flush_text(text, nodes).append(InlineCode(String.str_from_utf8(found.before)))
+					parse_inlines_help(found.after, [], next_nodes)
+				}
+
+				Err(_) =>
+					parse_inlines_help(rest, text.append('`'), nodes)
+			}
+		}
+
+		['[', .. as rest] => {
+			match find_sequence(rest, "](".to_utf8()) {
+				Ok(label) => {
+					match find_sequence(label.after, ")".to_utf8()) {
+						Ok(href) => {
+							next_nodes =
+								flush_text(text, nodes)
+									.append(InlineLink({ alt: parse_inlines(label.before), href: String.str_from_utf8(href.before) }))
+
+							parse_inlines_help(href.after, [], next_nodes)
+						}
+
+						Err(_) =>
+							parse_inlines_help(rest, text.append('['), nodes)
+					}
+				}
+
+				Err(_) =>
+					parse_inlines_help(rest, text.append('['), nodes)
+			}
+		}
+
+		[first, .. as rest] =>
+			parse_inlines_help(rest, text.append(first), nodes)
+	}
+}
+
+flush_text : String.Utf8, List(Inline) -> List(Inline)
+flush_text = |text, nodes| {
+	if text.is_empty() {
+		nodes
+	} else {
+		nodes.append(Text(String.str_from_utf8(text)))
+	}
+}
+
+find_sequence : String.Utf8, String.Utf8 -> Try({ before : String.Utf8, after : String.Utf8 }, [NotFound])
+find_sequence = |input, needle| {
+	find_sequence_help(input, needle, [])
+}
+
+find_sequence_help : String.Utf8, String.Utf8, String.Utf8 -> Try({ before : String.Utf8, after : String.Utf8 }, [NotFound])
+find_sequence_help = |input, needle, acc| {
+	if starts_with_bytes(input, needle) {
+		Ok({ before: acc, after: input.drop_first(needle.len()) })
+	} else {
+		match input {
+			[] =>
+				Err(NotFound)
+
+			[first, .. as rest] =>
+				find_sequence_help(rest, needle, acc.append(first))
+		}
+	}
+}
+
+starts_with_bytes : String.Utf8, String.Utf8 -> Bool
+starts_with_bytes = |input, prefix| {
+	{ before: start, others: _ } = input.split_at(prefix.len())
+	start == prefix
+}
+
+split_lines : String.Utf8 -> List(Line)
+split_lines = |input| {
+	split_lines_help(input, [], [])
+}
+
+split_lines_help : String.Utf8, String.Utf8, List(Line) -> List(Line)
+split_lines_help = |input, current, lines| {
+	match input {
+		[] =>
+			lines.append({ raw: current })
+
+		['\r', '\n', .. as rest] =>
+			split_lines_help(rest, [], lines.append({ raw: current }))
+
+		['\n', .. as rest] =>
+			split_lines_help(rest, [], lines.append({ raw: current }))
+
+		[first, .. as rest] =>
+			split_lines_help(rest, current.append(first), lines)
+	}
+}
+
+line_indent : Line -> U64
+line_indent = |line| {
+	count_leading_spaces(line.raw, 0)
+}
+
+count_leading_spaces : String.Utf8, U64 -> U64
+count_leading_spaces = |input, count| {
+	match input {
+		[' ', .. as rest] =>
+			count_leading_spaces(rest, count + 1)
+
+		_ =>
+			count
+	}
+}
+
+strip_indent : Line, U64 -> String.Utf8
+strip_indent = |line, indent| {
+	line.raw.drop_first(indent)
+}
+
+line_is_blank : Line -> Bool
+line_is_blank = |line| {
+	bytes_are_blank(line.raw)
+}
+
+bytes_are_blank : String.Utf8 -> Bool
+bytes_are_blank = |bytes| {
+	match bytes {
+		[] =>
+			Bool.True
+
+		[' ', .. as rest] =>
+			bytes_are_blank(rest)
+
+		['\t', .. as rest] =>
+			bytes_are_blank(rest)
+
+		_ =>
+			Bool.False
+	}
+}
+
+all_bytes_are : String.Utf8, U8 -> Bool
+all_bytes_are = |bytes, expected| {
+	match bytes {
+		[] =>
+			Bool.True
+
+		[first, .. as rest] =>
+			first == expected and all_bytes_are(rest, expected)
+	}
+}
+
+join_lines_with_spaces : List(String.Utf8) -> String.Utf8
+join_lines_with_spaces = |lines| {
+	join_lines_with_spaces_help(lines, [])
+}
+
+join_lines_with_spaces_help : List(String.Utf8), String.Utf8 -> String.Utf8
+join_lines_with_spaces_help = |lines, acc| {
+	match lines {
+		[] =>
+			acc
+
+		[line, .. as rest] if acc.is_empty() =>
+			join_lines_with_spaces_help(rest, append_bytes(acc, line))
+
+		[line, .. as rest] =>
+			join_lines_with_spaces_help(rest, append_bytes(acc.append(' '), line))
+	}
+}
+
+append_line : String.Utf8, String.Utf8 -> String.Utf8
+append_line = |acc, line| {
+	append_bytes(acc, line).append('\n')
+}
+
+append_bytes : String.Utf8, String.Utf8 -> String.Utf8
+append_bytes = |left, right| {
+	match right {
+		[] =>
+			left
+
+		[first, .. as rest] =>
+			append_bytes(left.append(first), rest)
+	}
+}
+
 # # temporyary parser for anything that is not yet supported
 # # just parse into a TODO tag for now
 todo : Parser(String.Utf8, Markdown)
-todo = 
+todo =
 	Parser.const(|s| TODO(s))
 		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
 
-## Unsupported markdown lines are preserved as TODO nodes.
+## Unsupported markdown lines can still be preserved as TODO nodes directly.
 expect {
 	a = String.parse_str(todo, "Foo Bar")?
 	a == TODO("Foo Bar")
 }
 
-## Multiple markdown lines parse into separate TODO nodes when unsupported.
+## Multiple markdown lines parse into paragraph nodes and blank lines separate blocks.
 expect {
 	a = String.parse_str(Markdown.all, "Foo Bar\n\nBaz")?
-	a == [TODO("Foo Bar"), TODO(""), TODO("Baz")]
+	a == [Paragraph([Text("Foo Bar")]), Paragraph([Text("Baz")])]
 }
 
 end_of_line = Parser.one_of([String.string("\n"), String.string("\r\n")])
@@ -177,7 +769,7 @@ expect {
 	a == Heading(Two, "Foo Bar")
 }
 
-inline_heading = 
+inline_heading =
 	Parser.const(
 		|level| {
 			|str| {
@@ -211,7 +803,7 @@ expect {
 	a == { val: Heading(Three, "Foo Bar"), input: "\nBaz" }
 }
 
-two_line_heading_level_one = 
+two_line_heading_level_one =
 	Parser.const(
 		|str| {
 			Heading(One, str)
@@ -240,7 +832,7 @@ expect {
 	a == { val: Heading(One, "Foo Bar"), input: "\n" }
 }
 
-two_line_heading_level_two = 
+two_line_heading_level_two =
 	Parser.const(
 		|str| {
 			Heading(Two, str)
@@ -293,10 +885,9 @@ expect {
 	a == { val: Image({ alt: "alt text", href: "/images/logo.png" }), input: "\nApples" }
 }
 
-# TODO: fix the following expect
 ## Code blocks capture their extension and body text.
 expect {
-	text = 
+	text =
 		\\```roc
 		\\# some code
 		\\foo = bar
@@ -306,8 +897,92 @@ expect {
 	a == Code({ ext: "roc", pre: "# some code\nfoo = bar\n" })
 }
 
+## Inline spans parse text, emphasis, strong, code, and prose links.
+expect {
+	actual = parse_inlines("Intro with **bold**, *em*, _also em_, `code`, and [a link](https://example.com).".to_utf8())
+
+	actual
+		== [
+			Text("Intro with "),
+			Strong([Text("bold")]),
+			Text(", "),
+			Emphasis([Text("em")]),
+			Text(", "),
+			Emphasis([Text("also em")]),
+			Text(", "),
+			InlineCode("code"),
+			Text(", and "),
+			InlineLink({ alt: [Text("a link")], href: "https://example.com" }),
+			Text("."),
+		]
+}
+
+## Article body markdown parses into structured blocks without TODO fallbacks.
+expect {
+	text =
+		\\# Title
+		\\
+		\\Intro with **bold**, `code`, and [a link](https://example.com).
+		\\
+		\\![alt text](/image.png)
+		\\
+		\\```roc
+		\\main = 1
+		\\```
+		\\
+		\\- One
+		\\  - Nested
+		\\
+		\\> Quote with **strong** text
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual
+		== [
+			Heading(One, "Title"),
+			Paragraph(
+				[
+					Text("Intro with "),
+					Strong([Text("bold")]),
+					Text(", "),
+					InlineCode("code"),
+					Text(", and "),
+					InlineLink({ alt: [Text("a link")], href: "https://example.com" }),
+					Text("."),
+				],
+			),
+			Image({ alt: "alt text", href: "/image.png" }),
+			Code({ ext: "roc", pre: "main = 1\n" }),
+			UnorderedList(
+				[
+					ListItem(
+						[Text("One")],
+						[
+							UnorderedList(
+								[
+									ListItem([Text("Nested")], []),
+								],
+							),
+						],
+					),
+				],
+			),
+			Blockquote(
+				[
+					Paragraph(
+						[
+							Text("Quote with "),
+							Strong([Text("strong")]),
+							Text(" text"),
+						],
+					),
+				],
+			),
+		]
+}
+
 chomp_until_code_block_end : Parser(String.Utf8, Str)
-chomp_until_code_block_end = 
+chomp_until_code_block_end =
 	Parser.build_primitive_parser(
 		|input| {
 			chomp_to_code_block_end_help({ val: List.with_capacity(1000), input })

--- a/package/Markdown.roc
+++ b/package/Markdown.roc
@@ -3,11 +3,13 @@ import String
 
 # # Content values
 Markdown := [
-	Heading(Level, Str),
+	Heading(Level, List(Inline)),
 	Paragraph(List(Inline)),
 	Blockquote(List(Markdown)),
 	UnorderedList(List(Markdown)),
+	OrderedList(List(Markdown)),
 	ListItem(List(Inline), List(Markdown)),
+	HorizontalRule,
 	Link({ alt : Str, href : Str }),
 	Image({ alt : Str, href : Str }),
 	Code({ ext : Str, pre : Str }),
@@ -26,11 +28,14 @@ Markdown := [
 	all : Parser(String.Utf8, List(Markdown))
 	all = parse_all
 
+	inlines : Parser(String.Utf8, List(Inline))
+	inlines = parse_inlines_parser
+
 	## Headings
 	##
 	## ```
-	## expect String.parse_str(heading, "# Foo Bar") == Ok(Heading(One, "Foo Bar"))
-	## expect String.parse_str(heading, "Foo Bar\n---") == Ok(Heading(Two, "Foo Bar"))
+	## expect String.parse_str(heading, "# Foo Bar") == Ok(Heading(One, [Text("Foo Bar")]))
+	## expect String.parse_str(heading, "Foo Bar\n---") == Ok(Heading(Two, [Text("Foo Bar")]))
 	## ```
 	heading : Parser(String.Utf8, Markdown)
 	heading =
@@ -191,7 +196,7 @@ parse_one_block = |lines, min_indent| {
 		[line, underline, .. as rest_after_heading] if can_be_setext_heading_text(line, min_indent) => {
 			match underline_level(underline, min_indent) {
 				Ok(level) =>
-					Ok({ val: Heading(level, String.str_from_utf8(strip_indent(line, min_indent))), input: rest_after_heading })
+					Ok({ val: Heading(level, parse_inlines(strip_indent(line, min_indent))), input: rest_after_heading })
 
 				Err(_) =>
 					parse_one_block_without_setext(lines, min_indent)
@@ -219,24 +224,23 @@ parse_one_block_without_setext = |lines, min_indent| {
 				Err(_) if is_code_fence_line(line, min_indent) =>
 					parse_code_block(lines, min_indent)
 
+				Err(_) if is_horizontal_rule_line(line, min_indent) =>
+					Ok({ val: HorizontalRule, input: rest })
+
 				Err(_) => {
 					match parse_image_line(content) {
 						Ok(block) =>
 							Ok({ val: block, input: rest })
 
 						Err(_) => {
-							match parse_link_line(content) {
-								Ok(block) =>
-									Ok({ val: block, input: rest })
-
-								Err(_) if is_blockquote_line(line, min_indent) =>
-									parse_blockquote(lines, min_indent)
-
-								Err(_) if is_list_item_line(line, min_indent) =>
-									parse_unordered_list(lines, min_indent)
-
-								Err(_) =>
-									parse_paragraph(lines, min_indent)
+							if is_blockquote_line(line, min_indent) {
+								parse_blockquote(lines, min_indent)
+							} else if is_unordered_list_item_line(line, min_indent) {
+								parse_unordered_list(lines, min_indent)
+							} else if is_ordered_list_item_line(line, min_indent) {
+								parse_ordered_list(lines, min_indent)
+							} else {
+								parse_paragraph(lines, min_indent)
 							}
 						}
 					}
@@ -342,23 +346,57 @@ collect_blockquote_lines = |lines, min_indent, acc| {
 
 parse_unordered_list : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
 parse_unordered_list = |lines, min_indent| {
-	parsed = parse_list_items(lines, min_indent, [])?
+	parsed = parse_list_items(lines, min_indent, [], unordered_list_item_content)?
 	Ok({ val: UnorderedList(parsed.val), input: parsed.input })
 }
 
-parse_list_items : List(Line), U64, List(Markdown) -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
-parse_list_items = |lines, min_indent, items| {
-	match lines {
-		[line, .. as rest] if is_list_item_line(line, min_indent) => {
-			content = strip_indent(line, min_indent).drop_first(2)
-			children = parse_blocks_from_lines(rest, min_indent + 2)?
-			item = ListItem(parse_inlines(content), children.val)
+parse_ordered_list : List(Line), U64 -> Try({ val : Markdown, input : List(Line) }, [ParsingFailure(Str)])
+parse_ordered_list = |lines, min_indent| {
+	parsed = parse_list_items(lines, min_indent, [], ordered_list_item_content)?
+	Ok({ val: OrderedList(parsed.val), input: parsed.input })
+}
 
-			parse_list_items(children.input, min_indent, items.append(item))
+parse_list_items : List(Line), U64, List(Markdown), (Line, U64 -> Try(String.Utf8, [NotFound])) -> Try({ val : List(Markdown), input : List(Line) }, [ParsingFailure(Str)])
+parse_list_items = |lines, min_indent, items, list_item_content| {
+	match lines {
+		[line, .. as rest] => {
+			match list_item_content(line, min_indent) {
+				Ok(content) => {
+					content_indent = min_indent + 2
+					continuation = collect_list_item_continuation(rest, content_indent, [content])
+					children = parse_blocks_from_lines(continuation.input, content_indent)?
+					item = ListItem(parse_inlines(join_lines_with_spaces(continuation.val)), children.val)
+
+					parse_list_items(children.input, min_indent, items.append(item), list_item_content)
+				}
+
+				Err(_) =>
+					Ok({ val: items, input: lines })
+			}
 		}
 
 		_ =>
 			Ok({ val: items, input: lines })
+	}
+}
+
+collect_list_item_continuation : List(Line), U64, List(String.Utf8) -> { val : List(String.Utf8), input : List(Line) }
+collect_list_item_continuation = |lines, content_indent, acc| {
+	match lines {
+		[] =>
+			{ val: acc, input: [] }
+
+		[line, ..] if line_is_blank(line) =>
+			{ val: acc, input: lines }
+
+		[line, ..] if line_indent(line) < content_indent =>
+			{ val: acc, input: lines }
+
+		[line, ..] if is_block_start(line, content_indent) =>
+			{ val: acc, input: lines }
+
+		[line, .. as rest] =>
+			collect_list_item_continuation(rest, content_indent, acc.append(strip_indent(line, content_indent)))
 	}
 }
 
@@ -370,11 +408,12 @@ is_block_start = |line, min_indent| {
 		content = strip_indent(line, min_indent)
 
 		is_hash_heading_line(content)
+			or is_horizontal_rule_line(line, min_indent)
 			or is_code_fence_line(line, min_indent)
 			or parse_image_line(content).is_ok()
-			or parse_link_line(content).is_ok()
 			or is_blockquote_line(line, min_indent)
-			or is_list_item_line(line, min_indent)
+			or is_unordered_list_item_line(line, min_indent)
+			or is_ordered_list_item_line(line, min_indent)
 	}
 }
 
@@ -407,22 +446,22 @@ parse_hash_heading_line : String.Utf8 -> Try(Markdown, [NotFound])
 parse_hash_heading_line = |content| {
 	match content {
 		['#', ' ', .. as text] =>
-			Ok(Heading(One, String.str_from_utf8(text)))
+			Ok(Heading(One, parse_inlines(text)))
 
 		['#', '#', ' ', .. as text] =>
-			Ok(Heading(Two, String.str_from_utf8(text)))
+			Ok(Heading(Two, parse_inlines(text)))
 
 		['#', '#', '#', ' ', .. as text] =>
-			Ok(Heading(Three, String.str_from_utf8(text)))
+			Ok(Heading(Three, parse_inlines(text)))
 
 		['#', '#', '#', '#', ' ', .. as text] =>
-			Ok(Heading(Four, String.str_from_utf8(text)))
+			Ok(Heading(Four, parse_inlines(text)))
 
 		['#', '#', '#', '#', '#', ' ', .. as text] =>
-			Ok(Heading(Five, String.str_from_utf8(text)))
+			Ok(Heading(Five, parse_inlines(text)))
 
 		['#', '#', '#', '#', '#', '#', ' ', .. as text] =>
-			Ok(Heading(Six, String.str_from_utf8(text)))
+			Ok(Heading(Six, parse_inlines(text)))
 
 		_ =>
 			Err(NotFound)
@@ -495,10 +534,94 @@ strip_blockquote_marker = |line, min_indent| {
 	}
 }
 
-is_list_item_line : Line, U64 -> Bool
-is_list_item_line = |line, min_indent| {
-	line_indent(line) == min_indent and starts_with_bytes(strip_indent(line, min_indent), "- ".to_utf8())
+is_unordered_list_item_line : Line, U64 -> Bool
+is_unordered_list_item_line = |line, min_indent| {
+	unordered_list_item_content(line, min_indent).is_ok()
 }
+
+unordered_list_item_content : Line, U64 -> Try(String.Utf8, [NotFound])
+unordered_list_item_content = |line, min_indent| {
+	if line_indent(line) == min_indent and starts_with_bytes(strip_indent(line, min_indent), "- ".to_utf8()) {
+		Ok(strip_indent(line, min_indent).drop_first(2))
+	} else {
+		Err(NotFound)
+	}
+}
+
+is_ordered_list_item_line : Line, U64 -> Bool
+is_ordered_list_item_line = |line, min_indent| {
+	ordered_list_item_content(line, min_indent).is_ok()
+}
+
+ordered_list_item_content : Line, U64 -> Try(String.Utf8, [NotFound])
+ordered_list_item_content = |line, min_indent| {
+	if line_indent(line) == min_indent {
+		ordered_marker_content(strip_indent(line, min_indent))
+	} else {
+		Err(NotFound)
+	}
+}
+
+ordered_marker_content : String.Utf8 -> Try(String.Utf8, [NotFound])
+ordered_marker_content = |content| {
+	match content {
+		[first, .. as rest] if is_digit_byte(first) =>
+			ordered_marker_content_help(rest)
+
+		_ =>
+			Err(NotFound)
+	}
+}
+
+ordered_marker_content_help : String.Utf8 -> Try(String.Utf8, [NotFound])
+ordered_marker_content_help = |content| {
+	match content {
+		['.', ' ', .. as rest] =>
+			Ok(rest)
+
+		[first, .. as rest] if is_digit_byte(first) =>
+			ordered_marker_content_help(rest)
+
+		_ =>
+			Err(NotFound)
+	}
+}
+
+is_horizontal_rule_line : Line, U64 -> Bool
+is_horizontal_rule_line = |line, min_indent| {
+	if line_indent(line) != min_indent {
+		Bool.False
+	} else {
+		content = strip_indent(line, min_indent)
+
+		match content {
+			['-', '-', '-', .. as rest] if all_bytes_are(rest, '-') =>
+				Bool.True
+
+			['*', '*', '*', .. as rest] if all_bytes_are(rest, '*') =>
+				Bool.True
+
+			['_', '_', '_', .. as rest] if all_bytes_are(rest, '_') =>
+				Bool.True
+
+			_ =>
+				Bool.False
+		}
+	}
+}
+
+is_digit_byte : U8 -> Bool
+is_digit_byte = |byte| {
+	byte >= '0' and byte <= '9'
+}
+
+parse_inlines_parser : Parser(String.Utf8, List(Inline))
+parse_inlines_parser =
+	Parser.build_primitive_parser(
+		|input| {
+			Ok({ val: parse_inlines(input), input: [] })
+		},
+	)
 
 parse_inlines : String.Utf8 -> List(Inline)
 parse_inlines = |input| {
@@ -511,8 +634,14 @@ parse_inlines_help = |input, text, nodes| {
 		[] =>
 			flush_text(text, nodes)
 
+		['\\', escaped, .. as rest] if is_escapable_inline_byte(escaped) =>
+			parse_inlines_help(rest, text.append(escaped), nodes)
+
+		['\\', .. as rest] =>
+			parse_inlines_help(rest, text.append('\\'), nodes)
+
 		['*', '*', .. as rest] => {
-			match find_sequence(rest, "**".to_utf8()) {
+			match find_unescaped_sequence(rest, "**".to_utf8()) {
 				Ok(found) => {
 					next_nodes = flush_text(text, nodes).append(Strong(parse_inlines(found.before)))
 					parse_inlines_help(found.after, [], next_nodes)
@@ -524,7 +653,7 @@ parse_inlines_help = |input, text, nodes| {
 		}
 
 		['*', .. as rest] => {
-			match find_sequence(rest, "*".to_utf8()) {
+			match find_unescaped_sequence(rest, "*".to_utf8()) {
 				Ok(found) => {
 					next_nodes = flush_text(text, nodes).append(Emphasis(parse_inlines(found.before)))
 					parse_inlines_help(found.after, [], next_nodes)
@@ -536,7 +665,7 @@ parse_inlines_help = |input, text, nodes| {
 		}
 
 		['_', .. as rest] => {
-			match find_sequence(rest, "_".to_utf8()) {
+			match find_unescaped_sequence(rest, "_".to_utf8()) {
 				Ok(found) => {
 					next_nodes = flush_text(text, nodes).append(Emphasis(parse_inlines(found.before)))
 					parse_inlines_help(found.after, [], next_nodes)
@@ -548,7 +677,7 @@ parse_inlines_help = |input, text, nodes| {
 		}
 
 		['`', .. as rest] => {
-			match find_sequence(rest, "`".to_utf8()) {
+			match find_unescaped_sequence(rest, "`".to_utf8()) {
 				Ok(found) => {
 					next_nodes = flush_text(text, nodes).append(InlineCode(String.str_from_utf8(found.before)))
 					parse_inlines_help(found.after, [], next_nodes)
@@ -560,9 +689,9 @@ parse_inlines_help = |input, text, nodes| {
 		}
 
 		['[', .. as rest] => {
-			match find_sequence(rest, "](".to_utf8()) {
+			match find_unescaped_sequence(rest, "](".to_utf8()) {
 				Ok(label) => {
-					match find_sequence(label.after, ")".to_utf8()) {
+					match find_unescaped_sequence(label.after, ")".to_utf8()) {
 						Ok(href) => {
 							next_nodes =
 								flush_text(text, nodes)
@@ -586,6 +715,18 @@ parse_inlines_help = |input, text, nodes| {
 	}
 }
 
+is_escapable_inline_byte : U8 -> Bool
+is_escapable_inline_byte = |byte| {
+	byte == '\\'
+		or byte == '*'
+		or byte == '_'
+		or byte == '`'
+		or byte == '['
+		or byte == ']'
+		or byte == '('
+		or byte == ')'
+}
+
 flush_text : String.Utf8, List(Inline) -> List(Inline)
 flush_text = |text, nodes| {
 	if text.is_empty() {
@@ -598,6 +739,29 @@ flush_text = |text, nodes| {
 find_sequence : String.Utf8, String.Utf8 -> Try({ before : String.Utf8, after : String.Utf8 }, [NotFound])
 find_sequence = |input, needle| {
 	find_sequence_help(input, needle, [])
+}
+
+find_unescaped_sequence : String.Utf8, String.Utf8 -> Try({ before : String.Utf8, after : String.Utf8 }, [NotFound])
+find_unescaped_sequence = |input, needle| {
+	find_unescaped_sequence_help(input, needle, [])
+}
+
+find_unescaped_sequence_help : String.Utf8, String.Utf8, String.Utf8 -> Try({ before : String.Utf8, after : String.Utf8 }, [NotFound])
+find_unescaped_sequence_help = |input, needle, acc| {
+	if starts_with_bytes(input, needle) {
+		Ok({ before: acc, after: input.drop_first(needle.len()) })
+	} else {
+		match input {
+			[] =>
+				Err(NotFound)
+
+			['\\', escaped, .. as rest] if is_escapable_inline_byte(escaped) =>
+				find_unescaped_sequence_help(rest, needle, acc.append('\\').append(escaped))
+
+			[first, .. as rest] =>
+				find_unescaped_sequence_help(rest, needle, acc.append(first))
+		}
+	}
 }
 
 find_sequence_help : String.Utf8, String.Utf8, String.Utf8 -> Try({ before : String.Utf8, after : String.Utf8 }, [NotFound])
@@ -760,20 +924,20 @@ not_end_of_line = |b| {
 ## Hash-prefixed headings parse with their heading level.
 expect {
 	a = String.parse_str(Markdown.heading, "# Foo Bar")?
-	a == Heading(One, "Foo Bar")
+	a == Heading(One, [Text("Foo Bar")])
 }
 
 ## Underlined headings parse as level two headings.
 expect {
 	a = String.parse_str(Markdown.heading, "Foo Bar\n---")?
-	a == Heading(Two, "Foo Bar")
+	a == Heading(Two, [Text("Foo Bar")])
 }
 
 inline_heading =
 	Parser.const(
 		|level| {
 			|str| {
-				Heading(level, str)
+				Heading(level, parse_inlines(str.to_utf8()))
 			}
 		},
 	)
@@ -794,19 +958,19 @@ inline_heading =
 ## Inline headings capture the heading text after the marker.
 expect {
 	a = String.parse_str(inline_heading, "# Foo Bar")?
-	a == Heading(One, "Foo Bar")
+	a == Heading(One, [Text("Foo Bar")])
 }
 
 ## Inline heading partial parsing leaves the following line untouched.
 expect {
 	a = String.parse_str_partial(inline_heading, "### Foo Bar\nBaz")?
-	a == { val: Heading(Three, "Foo Bar"), input: "\nBaz" }
+	a == { val: Heading(Three, [Text("Foo Bar")]), input: "\nBaz" }
 }
 
 two_line_heading_level_one =
 	Parser.const(
 		|str| {
-			Heading(One, str)
+			Heading(One, parse_inlines(str.to_utf8()))
 		},
 	)
 		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
@@ -823,19 +987,19 @@ two_line_heading_level_one =
 ## Equal-sign underlines parse as level one headings.
 expect {
 	a = String.parse_str(two_line_heading_level_one, "Foo Bar\n==")?
-	a == Heading(One, "Foo Bar")
+	a == Heading(One, [Text("Foo Bar")])
 }
 
 ## Level one heading partial parsing leaves the trailing newline.
 expect {
 	a = String.parse_str_partial(two_line_heading_level_one, "Foo Bar\n=============\n")?
-	a == { val: Heading(One, "Foo Bar"), input: "\n" }
+	a == { val: Heading(One, [Text("Foo Bar")]), input: "\n" }
 }
 
 two_line_heading_level_two =
 	Parser.const(
 		|str| {
-			Heading(Two, str)
+			Heading(Two, parse_inlines(str.to_utf8()))
 		},
 	)
 		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
@@ -852,13 +1016,13 @@ two_line_heading_level_two =
 ## Dash underlines parse as level two headings.
 expect {
 	a = String.parse_str(two_line_heading_level_two, "Foo Bar\n---")?
-	a == Heading(Two, "Foo Bar")
+	a == Heading(Two, [Text("Foo Bar")])
 }
 
 ## Level two heading partial parsing leaves the following line.
 expect {
 	a = String.parse_str_partial(two_line_heading_level_two, "Foo Bar\n-----\nApples")?
-	a == { val: Heading(Two, "Foo Bar"), input: "\nApples" }
+	a == { val: Heading(Two, [Text("Foo Bar")]), input: "\nApples" }
 }
 
 ## Markdown links capture their label and target URL.
@@ -897,9 +1061,9 @@ expect {
 	a == Code({ ext: "roc", pre: "# some code\nfoo = bar\n" })
 }
 
-## Inline spans parse text, emphasis, strong, code, and prose links.
+## Public inline parser parses text, emphasis, strong, code, and prose links.
 expect {
-	actual = parse_inlines("Intro with **bold**, *em*, _also em_, `code`, and [a link](https://example.com).".to_utf8())
+	actual = String.parse_str(Markdown.inlines, "Intro with **bold**, *em*, _also em_, `code`, and [a link](https://example.com).")?
 
 	actual
 		== [
@@ -915,6 +1079,97 @@ expect {
 			InlineLink({ alt: [Text("a link")], href: "https://example.com" }),
 			Text("."),
 		]
+}
+
+## Escaped inline delimiters parse as literal text.
+expect {
+	text = "\\*literal\\*, \\_em\\_, \\`code\\`, and \\[a link](https://example.com)"
+
+	actual = String.parse_str(Markdown.inlines, text)?
+
+	actual == [Text("*literal*, _em_, `code`, and [a link](https://example.com)")]
+}
+
+## Heading text can contain inline spans.
+expect {
+	actual = String.parse_str(Markdown.heading, "# Title with **strong** text")?
+
+	actual
+		== Heading(
+			One,
+			[
+				Text("Title with "),
+				Strong([Text("strong")]),
+				Text(" text"),
+			],
+		)
+}
+
+## Standalone links in documents parse as paragraph inline links.
+expect {
+	actual = String.parse_str(Markdown.all, "[roc](https://roc-lang.org)")?
+
+	actual
+		== [
+			Paragraph(
+				[
+					InlineLink({ alt: [Text("roc")], href: "https://roc-lang.org" }),
+				],
+			),
+		]
+}
+
+## Horizontal rules parse as block nodes.
+expect {
+	actual = String.parse_str(Markdown.all, "---")?
+
+	actual == [HorizontalRule]
+}
+
+## Ordered list items parse into ordered list blocks.
+expect {
+	text =
+		\\1. One
+		\\2. Two
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual
+		== [
+			OrderedList(
+				[
+					ListItem([Text("One")], []),
+					ListItem([Text("Two")], []),
+				],
+			),
+		]
+}
+
+## Indented list continuation lines are folded into the item text.
+expect {
+	text =
+		\\- first line
+		\\  continued line
+
+	actual = String.parse_str(Markdown.all, text)?
+
+	actual
+		== [
+			UnorderedList(
+				[
+					ListItem([Text("first line continued line")], []),
+				],
+			),
+		]
+}
+
+## Unclosed fenced code blocks fail document parsing.
+expect {
+	text =
+		\\```roc
+		\\main = 1
+
+	String.parse_str(Markdown.all, text).is_err()
 }
 
 ## Article body markdown parses into structured blocks without TODO fallbacks.
@@ -939,7 +1194,7 @@ expect {
 
 	actual
 		== [
-			Heading(One, "Title"),
+			Heading(One, [Text("Title")]),
 			Paragraph(
 				[
 					Text("Intro with "),

--- a/package/Markdown.roc
+++ b/package/Markdown.roc
@@ -3,36 +3,116 @@ import String
 
 # # Content values
 Markdown := [
-	Heading({ level : Level, content : List(Inline) }),
-	Paragraph(List(Inline)),
+	Heading({ level : Markdown.Level, content : List(Markdown.Inline) }),
+	Paragraph(List(Markdown.Inline)),
 	Blockquote(List(Markdown)),
-	ListBlock({ kind : ListKind, loose : Bool, items : List({ task : TaskState, blocks : List(Markdown) }) }),
+	ListBlock({ kind : Markdown.ListKind, loose : Bool, items : List({ task : Markdown.TaskState, blocks : List(Markdown) }) }),
 	Code({ info : Str, pre : Str }),
 	ThematicBreak,
-	Table({ header : List(List(Inline)), align : List(Alignment), rows : List(List(List(Inline))) }),
+	Table({ header : List(List(Markdown.Inline)), align : List(Markdown.Alignment), rows : List(List(List(Markdown.Inline))) }),
 	HtmlBlock(Str),
 	Frontmatter({ raw : Str }),
 	TODO(Str),
 ].{
-	Level : [One, Two, Three, Four, Five, Six]
+	to_inspect : Markdown -> Str
+	to_inspect = |node| {
+		inspect_markdown(node)
+	}
 
-	ListKind : [
+	is_eq : Markdown, Markdown -> Bool
+	is_eq = |left, right| {
+		markdown_is_eq(left, right)
+	}
+
+	to_debug_str : Markdown -> Str
+	to_debug_str = |node| {
+		inspect_markdown(node)
+	}
+
+	inline_to_debug_str : Markdown.Inline -> Str
+	inline_to_debug_str = |inline| {
+		inspect_inline(inline)
+	}
+
+	Level := [One, Two, Three, Four, Five, Six].{
+		to_inspect : Level -> Str
+		to_inspect = |level| {
+			inspect_level(level)
+		}
+
+		to_str : Level -> Str
+		to_str = |level| {
+			level_to_str(level)
+		}
+
+		is_eq : Level, Level -> Bool
+		is_eq = |left, right| {
+			level_is_eq(left, right)
+		}
+	}
+
+	ListKind := [
 		Unordered,
 		Ordered({ start : U64 }),
-	]
+	].{
+		to_inspect : ListKind -> Str
+		to_inspect = |kind| {
+			inspect_list_kind(kind)
+		}
 
-	TaskState : [
+		to_str : ListKind -> Str
+		to_str = |kind| {
+			list_kind_to_str(kind)
+		}
+
+		is_eq : ListKind, ListKind -> Bool
+		is_eq = |left, right| {
+			list_kind_is_eq(left, right)
+		}
+	}
+
+	TaskState := [
 		NoTask,
 		Unchecked,
 		Checked,
-	]
+	].{
+		to_inspect : TaskState -> Str
+		to_inspect = |task| {
+			inspect_task_state(task)
+		}
 
-	Alignment : [
+		to_str : TaskState -> Str
+		to_str = |task| {
+			task_state_to_str(task)
+		}
+
+		is_eq : TaskState, TaskState -> Bool
+		is_eq = |left, right| {
+			task_state_is_eq(left, right)
+		}
+	}
+
+	Alignment := [
 		Default,
 		Left,
 		Center,
 		Right,
-	]
+	].{
+		to_inspect : Alignment -> Str
+		to_inspect = |alignment| {
+			inspect_alignment(alignment)
+		}
+
+		to_str : Alignment -> Str
+		to_str = |alignment| {
+			alignment_to_str(alignment)
+		}
+
+		is_eq : Alignment, Alignment -> Bool
+		is_eq = |left, right| {
+			alignment_is_eq(left, right)
+		}
+	}
 
 	LinkTarget : {
 		href : Str,
@@ -49,7 +129,17 @@ Markdown := [
 		Image({ alt : List(Inline), target : LinkTarget }),
 		HardBreak,
 		HtmlInline(Str),
-	]
+	].{
+		to_inspect : Inline -> Str
+		to_inspect = |inline| {
+			inspect_inline(inline)
+		}
+
+		is_eq : Inline, Inline -> Bool
+		is_eq = |left, right| {
+			inline_is_eq(left, right)
+		}
+	}
 
 	all : Parser(String.Utf8, List(Markdown))
 	all = parse_all
@@ -137,6 +227,275 @@ Markdown := [
 				),
 			)
 			.keep(chomp_until_code_block_end)
+}
+
+inspect_markdown : Markdown -> Str
+inspect_markdown = |node| {
+	match node {
+		Heading({ level, content }) =>
+			"Heading({ level: ${Str.inspect(level)}, content: ${Str.inspect(content)} })"
+
+		Paragraph(content) =>
+			"Paragraph(${Str.inspect(content)})"
+
+		Blockquote(children) =>
+			"Blockquote(${Str.inspect(children)})"
+
+		ListBlock({ kind, loose, items }) =>
+			"ListBlock({ kind: ${Str.inspect(kind)}, loose: ${Str.inspect(loose)}, items: ${Str.inspect(items)} })"
+
+		Code({ info, pre }) =>
+			"Code({ info: ${Str.inspect(info)}, pre: ${Str.inspect(pre)} })"
+
+		ThematicBreak =>
+			"ThematicBreak"
+
+		Table({ header, align, rows }) =>
+			"Table({ header: ${Str.inspect(header)}, align: ${Str.inspect(align)}, rows: ${Str.inspect(rows)} })"
+
+		HtmlBlock(raw) =>
+			"HtmlBlock(${Str.inspect(raw)})"
+
+		Frontmatter({ raw }) =>
+			"Frontmatter({ raw: ${Str.inspect(raw)} })"
+
+		TODO(line) =>
+			"TODO(${Str.inspect(line)})"
+	}
+}
+
+markdown_is_eq : Markdown, Markdown -> Bool
+markdown_is_eq = |left, right| {
+	match { left, right } {
+		{ left: Heading(l), right: Heading(r) } =>
+			l.level == r.level and l.content == r.content
+
+		{ left: Paragraph(l), right: Paragraph(r) } =>
+			l == r
+
+		{ left: Blockquote(l), right: Blockquote(r) } =>
+			l == r
+
+		{ left: ListBlock(l), right: ListBlock(r) } =>
+			l.kind == r.kind and l.loose == r.loose and l.items == r.items
+
+		{ left: Code(l), right: Code(r) } =>
+			l.info == r.info and l.pre == r.pre
+
+		{ left: ThematicBreak, right: ThematicBreak } =>
+			Bool.True
+
+		{ left: Table(l), right: Table(r) } =>
+			l.header == r.header and l.align == r.align and l.rows == r.rows
+
+		{ left: HtmlBlock(l), right: HtmlBlock(r) } =>
+			l == r
+
+		{ left: Frontmatter(l), right: Frontmatter(r) } =>
+			l.raw == r.raw
+
+		{ left: TODO(l), right: TODO(r) } =>
+			l == r
+
+		_ =>
+			Bool.False
+	}
+}
+
+inspect_level : Markdown.Level -> Str
+inspect_level = |level| {
+	match level {
+		One => "One"
+		Two => "Two"
+		Three => "Three"
+		Four => "Four"
+		Five => "Five"
+		Six => "Six"
+	}
+}
+
+level_to_str : Markdown.Level -> Str
+level_to_str = |level| {
+	match level {
+		One => "1"
+		Two => "2"
+		Three => "3"
+		Four => "4"
+		Five => "5"
+		Six => "6"
+	}
+}
+
+level_is_eq : Markdown.Level, Markdown.Level -> Bool
+level_is_eq = |left, right| {
+	level_to_str(left) == level_to_str(right)
+}
+
+inspect_list_kind : Markdown.ListKind -> Str
+inspect_list_kind = |kind| {
+	match kind {
+		Unordered =>
+			"Unordered"
+
+		Ordered({ start }) =>
+			"Ordered({ start: ${start.to_str()} })"
+	}
+}
+
+list_kind_to_str : Markdown.ListKind -> Str
+list_kind_to_str = |kind| {
+	match kind {
+		Unordered =>
+			"unordered"
+
+		Ordered({ start }) =>
+			"ordered:${start.to_str()}"
+	}
+}
+
+list_kind_is_eq : Markdown.ListKind, Markdown.ListKind -> Bool
+list_kind_is_eq = |left, right| {
+	match { left, right } {
+		{ left: Unordered, right: Unordered } =>
+			Bool.True
+
+		{ left: Ordered(l), right: Ordered(r) } =>
+			l.start == r.start
+
+		_ =>
+			Bool.False
+	}
+}
+
+inspect_task_state : Markdown.TaskState -> Str
+inspect_task_state = |task| {
+	match task {
+		NoTask => "NoTask"
+		Unchecked => "Unchecked"
+		Checked => "Checked"
+	}
+}
+
+task_state_to_str : Markdown.TaskState -> Str
+task_state_to_str = |task| {
+	match task {
+		NoTask => "none"
+		Unchecked => "unchecked"
+		Checked => "checked"
+	}
+}
+
+task_state_is_eq : Markdown.TaskState, Markdown.TaskState -> Bool
+task_state_is_eq = |left, right| {
+	task_state_to_str(left) == task_state_to_str(right)
+}
+
+inspect_alignment : Markdown.Alignment -> Str
+inspect_alignment = |alignment| {
+	match alignment {
+		Default => "Default"
+		Left => "Left"
+		Center => "Center"
+		Right => "Right"
+	}
+}
+
+alignment_to_str : Markdown.Alignment -> Str
+alignment_to_str = |alignment| {
+	match alignment {
+		Default => "default"
+		Left => "left"
+		Center => "center"
+		Right => "right"
+	}
+}
+
+alignment_is_eq : Markdown.Alignment, Markdown.Alignment -> Bool
+alignment_is_eq = |left, right| {
+	alignment_to_str(left) == alignment_to_str(right)
+}
+
+inspect_inline : Markdown.Inline -> Str
+inspect_inline = |inline| {
+	match inline {
+		Text(text) =>
+			"Text(${Str.inspect(text)})"
+
+		Strong(children) =>
+			"Strong(${Str.inspect(children)})"
+
+		Emphasis(children) =>
+			"Emphasis(${Str.inspect(children)})"
+
+		Strikethrough(children) =>
+			"Strikethrough(${Str.inspect(children)})"
+
+		InlineCode(code) =>
+			"InlineCode(${Str.inspect(code)})"
+
+		Link({ label, target }) =>
+			"Link({ label: ${Str.inspect(label)}, target: ${inspect_link_target(target)} })"
+
+		Image({ alt, target }) =>
+			"Image({ alt: ${Str.inspect(alt)}, target: ${inspect_link_target(target)} })"
+
+		HardBreak =>
+			"HardBreak"
+
+		HtmlInline(raw) =>
+			"HtmlInline(${Str.inspect(raw)})"
+	}
+}
+
+inline_is_eq : Markdown.Inline, Markdown.Inline -> Bool
+inline_is_eq = |left, right| {
+	match { left, right } {
+		{ left: Text(l), right: Text(r) } =>
+			l == r
+
+		{ left: Strong(l), right: Strong(r) } =>
+			l == r
+
+		{ left: Emphasis(l), right: Emphasis(r) } =>
+			l == r
+
+		{ left: Strikethrough(l), right: Strikethrough(r) } =>
+			l == r
+
+		{ left: InlineCode(l), right: InlineCode(r) } =>
+			l == r
+
+		{ left: Link(l), right: Link(r) } =>
+			l.label == r.label and l.target == r.target
+
+		{ left: Image(l), right: Image(r) } =>
+			l.alt == r.alt and l.target == r.target
+
+		{ left: HardBreak, right: HardBreak } =>
+			Bool.True
+
+		{ left: HtmlInline(l), right: HtmlInline(r) } =>
+			l == r
+
+		_ =>
+			Bool.False
+	}
+}
+
+inspect_link_target : Markdown.LinkTarget -> Str
+inspect_link_target = |target| {
+	"{ href: ${Str.inspect(target.href)}, title: ${inspect_link_title(target.title)} }"
+}
+
+inspect_link_title : [Some(Str), None] -> Str
+inspect_link_title = |title| {
+	match title {
+		Some(value) =>
+			"Some(${Str.inspect(value)})"
+
+		None =>
+			"None"
+	}
 }
 
 Line : { raw : String.Utf8 }
@@ -1938,6 +2297,84 @@ todo =
 expect {
 	a = String.parse_str(todo, "Foo Bar")?
 	a == TODO("Foo Bar")
+}
+
+## Small nominal support types expose equality, debug, and string helpers.
+expect {
+	level : Markdown.Level
+	level = Two
+
+	kind : Markdown.ListKind
+	kind = Ordered({ start: 3 })
+
+	task : Markdown.TaskState
+	task = Checked
+
+	alignment : Markdown.Alignment
+	alignment = Right
+
+	actual =
+		\\level inspect: ${Str.inspect(level)}
+		\\level str: ${level.to_str()}
+		\\level eq: ${Str.inspect(level == Two)}
+		\\kind inspect: ${Str.inspect(kind)}
+		\\kind str: ${kind.to_str()}
+		\\kind eq same: ${Str.inspect(kind == Ordered({ start: 3 }))}
+		\\kind eq different: ${Str.inspect(kind == Ordered({ start: 4 }))}
+		\\task inspect: ${Str.inspect(task)}
+		\\task str: ${task.to_str()}
+		\\task eq: ${Str.inspect(task == Checked)}
+		\\alignment inspect: ${Str.inspect(alignment)}
+		\\alignment str: ${alignment.to_str()}
+		\\alignment eq: ${Str.inspect(alignment == Right)}
+
+	expected =
+		\\level inspect: Two
+		\\level str: 2
+		\\level eq: True
+		\\kind inspect: Ordered({ start: 3 })
+		\\kind str: ordered:3
+		\\kind eq same: True
+		\\kind eq different: False
+		\\task inspect: Checked
+		\\task str: checked
+		\\task eq: True
+		\\alignment inspect: Right
+		\\alignment str: right
+		\\alignment eq: True
+
+	actual == expected
+}
+
+## Inline and block AST nodes expose useful inspect strings and structural equality.
+expect {
+	inline : Markdown.Inline
+	inline = Strong([Text("Roc")])
+
+	block : Markdown
+	block = Heading({ level: Two, content: [Text("Roc")] })
+
+	actual =
+		\\inline inspect: ${Str.inspect(inline)}
+		\\inline debug: ${Markdown.inline_to_debug_str(inline)}
+		\\inline eq same: ${Str.inspect(inline == Strong([Text("Roc")]))}
+		\\inline eq different: ${Str.inspect(inline == Emphasis([Text("Roc")]))}
+		\\block inspect: ${Str.inspect(block)}
+		\\block debug: ${Markdown.to_debug_str(block)}
+		\\block eq same: ${Str.inspect(block == Heading({ level: Two, content: [Text("Roc")] }))}
+		\\block eq different: ${Str.inspect(block == Paragraph([Text("Roc")]))}
+
+	expected =
+		\\inline inspect: Strong([Text("Roc")])
+		\\inline debug: Strong([Text("Roc")])
+		\\inline eq same: True
+		\\inline eq different: False
+		\\block inspect: Heading({ level: Two, content: [Text("Roc")] })
+		\\block debug: Heading({ level: Two, content: [Text("Roc")] })
+		\\block eq same: True
+		\\block eq different: False
+
+	actual == expected
 }
 
 ## Hash-prefixed headings parse with inline content.


### PR DESCRIPTION
Implements #35 and expands the Markdown module into a broader article/GFM-style subset.

Summary:
- Reshapes the public Markdown AST around tag unions with record payloads for headings, lists, code, tables, frontmatter, and links/images.
- Adds frontmatter preservation, reference definition resolution, inline images, direct/reference links/images, autolinks, bare URLs, strikethrough, hard breaks, and raw inline HTML.
- Adds list marker variants, ordered-list start preservation, task list state, loose-list detection, nested lists, thematic breaks, tilde fences, indented code blocks, GFM pipe tables, and raw HTML blocks.
- Adds nominal helper hooks for the Markdown AST: `to_inspect` for `Str.inspect`, `is_eq` for `==`, debug helpers, and `to_str` for small support types.
- Keeps Markdown.all, Markdown.inlines, Markdown.heading, Markdown.link, Markdown.image, and Markdown.code available with the new AST shapes.
- Updates examples/markdown.roc to render the expanded AST and use the new support-type helpers.
- Removes the stale markdown example skip after the stack overflow could not be reproduced.

Implementation notes:
- Uses a document pre-pass for frontmatter and reference definitions.
- Uses shared block/inline scanners instead of one-off parsers for each syntax variant.
- Uses Iter/List.from_iter for stateless transformations such as table cell/alignment parsing and reference-label normalization.

Tests:
- roc test package/Markdown.roc: 56 tests
- ci/all_tests.sh
