### PR TITLE
Add YAML config parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Includes modules to parse the following (with various levels of maturity);
 - XML
 - Markdown
 - HTTP
+- YAML configuration files and Markdown frontmatter
+
+The YAML module supports a practical single-document subset: nested block
+mappings and sequences, flow collections, comments, quoted strings, and common
+scalar values. It deliberately rejects advanced features such as anchors,
+aliases, tags, directives, block scalars, complex keys, and document streams.
 
 ## Documentation
 

--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -39,6 +39,7 @@ echo "Skipping package/HTTP.roc tests: latest nightly segfaults in the compiler 
 "$ROC_BIN" test package/Markdown.roc
 "$ROC_BIN" test package/String.roc
 "$ROC_BIN" test package/Xml.roc
+"$ROC_BIN" test package/Yaml.roc
 
 echo ""
 echo "Generating package docs..."

--- a/examples/csv-movies.roc
+++ b/examples/csv-movies.roc
@@ -17,7 +17,7 @@ MovieInfo : { title : Str, release_year : U64, actors : List(Str) }
 
 main! : List(Str) => Try({}, _)
 main! = |args| {
-	csv_input = args.first() ?? input
+	csv_input = args.drop_first(1).first() ?? input
 
 	match CSV.parse_str(movie_info_parser, csv_input) {
 		Ok(movies) => {

--- a/examples/letters.roc
+++ b/examples/letters.roc
@@ -10,7 +10,7 @@ import parser.String
 
 main! : List(Str) => Try({}, _)
 main! = |args| {
-	input = args.first() ?? "AAAiBByAABBwBtCCCiAyArBBx"
+	input = args.drop_first(1).first() ?? "AAAiBByAABBwBtCCCiAyArBBx"
 	result : Try(List(Letter), [ParsingFailure(Str), ParsingIncomplete(Str)])
 	result = String.parse_str(letter_parser.many(), input)
 

--- a/examples/markdown.roc
+++ b/examples/markdown.roc
@@ -41,7 +41,7 @@ content =
 
 main! : List(Str) => Try({}, _)
 main! = |args| {
-	markdown_input = args.first() ?? content
+	markdown_input = args.drop_first(1).first() ?? content
 	parsed = 
 		String.parse_str(Markdown.all, markdown_input)
 			.map_ok(

--- a/examples/numbers.roc
+++ b/examples/numbers.roc
@@ -10,7 +10,7 @@ import parser.String
 
 main! : List(Str) => Try({}, _)
 main! = |args| {
-	input = args.first() ?? "1000\n2000\n3000\n\n4000\n\n5000\n6000\n\n"
+	input = args.drop_first(1).first() ?? "1000\n2000\n3000\n\n4000\n\n5000\n6000\n\n"
 	result : Try(List(List(U64)), [ParsingFailure(Str), ParsingIncomplete(Str)])
 	result = String.parse_str(multiple_numbers.many(), input)
 

--- a/package/CSV.roc
+++ b/package/CSV.roc
@@ -1,20 +1,21 @@
 import Parser
 import String
 
-# # This is a CSV parser which follows RFC4180
-# #
-# # For simplicity's sake, the following things are not yet supported:
-# # - CSV files with headings
-# #
-# # The following however *is* supported
-# # - A simple LF ("\n") instead of CRLF ("\r\n") to separate records.
+## RFC 4180-style CSV parsing and typed record decoding.
+##
+## Quoted fields, escaped double quotes, CRLF record separators, and simple LF
+## separators are supported. The first row is treated as data rather than as headings.
 CSV :: { records : List(List(String.Utf8)) }.{
+	## Compare two decoded CSV values structurally.
 	is_eq : _
 
+	## One CSV row represented as a list of raw UTF-8 fields.
 	CSVRecord : List(CSVField)
+
+	## One raw UTF-8 field from a CSV row.
 	CSVField : String.Utf8
 
-	# # Attempts to Parser.parse an `a` from a `Str` that is encoded in CSV format.
+	## Parse CSV text and decode every record with the supplied record parser.
 	parse_str : Parser(CSVRecord, a), Str -> Try(List(a), [ParsingFailure(Str), SyntaxError(Str), ParsingIncomplete(CSVRecord)])
 	parse_str = |csv_parser, input| {
 		match parse_str_to_csv(input) {
@@ -46,7 +47,7 @@ CSV :: { records : List(List(String.Utf8)) }.{
 		}
 	}
 
-	# # Attempts to Parser.parse an `a` from a `CSV` datastructure (a list of lists of bytestring-fields).
+	## Decode every record in an already parsed `CSV` value.
 	parse_csv : Parser(CSVRecord, a), CSV -> Try(List(a), [ParsingFailure(Str), ParsingIncomplete(CSVRecord)])
 	parse_csv = |csv_parser, { records: csv_data }| {
 		csv_data
@@ -93,9 +94,9 @@ CSV :: { records : List(List(String.Utf8)) }.{
 			)
 	}
 
-	# # Attempts to Parser.parse an `a` from a `CSVRecord` datastructure (a list of bytestring-fields)
+	## Decode one `CSVRecord` with the supplied record parser.
 	##
-	# # This parser succeeds when all fields of the CSVRecord are consumed by the parser.
+	## Parsing succeeds only when the record parser consumes every field.
 	parse_csv_record : Parser(CSVRecord, a), CSVRecord -> Try(a, [ParsingFailure(Str), ParsingIncomplete(CSVRecord)])
 	parse_csv_record = |csv_parser, record_fields_list| {
 		Parser.parse(
@@ -107,20 +108,20 @@ CSV :: { records : List(List(String.Utf8)) }.{
 		)
 	}
 
-	# # Wrapper function to combine a set of fields into your desired `a`
+	## Start a record parser with a curried constructor for the desired value.
 	##
-	# # ```roc
-	# # record(|first_name| |last_name| |age| User({ first_name, last_name, age }))
-	# # .field(string)
-	# # .field(string)
-	# # .field(u64)
-	# # ```
+	## ```roc
+	## record(|first_name| |last_name| |age| User({ first_name, last_name, age }))
+	## .field(string)
+	## .field(string)
+	## .field(u64)
+	## ```
 	record : a -> Parser(CSVRecord, a)
 	record = |f| {
 		Parser.const(f)
 	}
 
-	# # Turns a parser for a `List(U8)` into a parser that parses part of a `CSVRecord`.
+	## Consume the next field of a `CSVRecord` using a UTF-8 field parser.
 	field : Parser(String.Utf8, a) -> Parser(CSVRecord, a)
 	field = |field_parser| {
 		Parser.build_primitive_parser(
@@ -157,11 +158,11 @@ CSV :: { records : List(List(String.Utf8)) }.{
 		)
 	}
 
-	# # Parser for a field containing a UTF8-encoded string
+	## Parse one CSV field as a valid UTF-8 string.
 	string : Parser(CSVField, Str)
 	string = String.any_string
 
-	# # Parse a number from a CSV field
+	## Parse one CSV field as an unsigned 64-bit integer.
 	u64 : Parser(CSVField, U64)
 	u64 = 
 		string
@@ -175,7 +176,7 @@ CSV :: { records : List(List(String.Utf8)) }.{
 			)
 			.flatten()
 
-	# # Parse a 64-bit float from a CSV field
+	## Parse one CSV field as a 64-bit floating-point number.
 	f64 : Parser(CSVField, F64)
 	f64 = 
 		string
@@ -189,7 +190,7 @@ CSV :: { records : List(List(String.Utf8)) }.{
 			)
 			.flatten()
 
-	# # Attempts to Parser.parse a Str into the internal `CSV` datastructure (A list of lists of bytestring-fields).
+	## Parse CSV text into raw records and UTF-8 fields.
 	parse_str_to_csv : Str -> Try(CSV, [ParsingFailure(Str), ParsingIncomplete(String.Utf8)])
 	parse_str_to_csv = |input| {
 		Parser.parse(
@@ -201,7 +202,7 @@ CSV :: { records : List(List(String.Utf8)) }.{
 		)
 	}
 
-	# # Attempts to Parser.parse a Str into the internal `CSVRecord` datastructure (A list of bytestring-fields).
+	## Parse one CSV row into raw UTF-8 fields.
 	parse_str_to_csv_record : Str -> Try(CSVRecord, [ParsingFailure(Str), ParsingIncomplete(String.Utf8)])
 	parse_str_to_csv_record = |input| {
 		Parser.parse(
@@ -213,7 +214,7 @@ CSV :: { records : List(List(String.Utf8)) }.{
 		)
 	}
 
-	# The following are parsers to turn strings into CSV structures
+	## Parse a complete RFC 4180-style CSV file into raw records and fields.
 	file : Parser(String.Utf8, CSV)
 	file = 
 		Parser.sep_by(csv_record, end_of_line)

--- a/package/CSV.roc
+++ b/package/CSV.roc
@@ -9,6 +9,8 @@ import String
 # # The following however *is* supported
 # # - A simple LF ("\n") instead of CRLF ("\r\n") to separate records.
 CSV :: { records : List(List(String.Utf8)) }.{
+	is_eq : _
+
 	CSVRecord : List(CSVField)
 	CSVField : String.Utf8
 
@@ -254,18 +256,25 @@ twodquotes = String.string("\"\"")
 nonescaped_csv_field : Parser(String.Utf8, CSV.CSVField)
 nonescaped_csv_field = textdata.many()
 
+comma : Parser(String.Utf8, U8)
 comma = String.codeunit(',')
 
+dquote : Parser(String.Utf8, U8)
 dquote = String.codeunit('"')
 
+end_of_line : Parser(String.Utf8, {})
 end_of_line = Parser.alt(Parser.ignore(crlf), Parser.ignore(lf))
 
+cr : Parser(String.Utf8, U8)
 cr = String.codeunit('\r')
 
+lf : Parser(String.Utf8, U8)
 lf = String.codeunit('\n')
 
+crlf : Parser(String.Utf8, Str)
 crlf = String.string("\r\n")
 
+textdata : Parser(String.Utf8, U8)
 textdata = String.codeunit_satisfies(
 	|x| {
 		(x >= 32 and x <= 33) or (x >= 35 and x <= 43) or (x >= 45 and x <= 126)

--- a/package/HTTP.roc
+++ b/package/HTTP.roc
@@ -1,13 +1,21 @@
 import Parser
 import String
 
+## Parsers and syntax types for basic HTTP/1.x requests and responses.
+##
+## Message bodies are returned as raw bytes. Header names and values are
+## preserved as strings without normalization.
 HTTP :: {}.{
+	## Supported HTTP request methods.
 	Method : [Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch]
 
+	## An HTTP protocol version such as `HTTP/1.1`.
 	HttpVersion : { major : U8, minor : U8 }
 
+	## One HTTP header name and value.
 	Header : [Header(Str, Str)]
 
+	## A parsed HTTP request message.
 	Request : {
 		method : Method,
 		uri : Str,
@@ -16,6 +24,7 @@ HTTP :: {}.{
 		body : List(U8),
 	}
 
+	## A parsed HTTP response message.
 	Response : {
 		http_version : HttpVersion,
 		status_code : U16,
@@ -24,6 +33,7 @@ HTTP :: {}.{
 		body : List(U8),
 	}
 
+	## Parse a complete HTTP request line, headers, and remaining body bytes.
 	request : Parser(String.Utf8, Request)
 	request = 
 		Parser.const(
@@ -49,6 +59,7 @@ HTTP :: {}.{
 			.skip(crlf)
 			.keep(String.any_thing)
 
+	## Parse a complete HTTP response line, headers, and remaining body bytes.
 	response : Parser(String.Utf8, Response)
 	response = 
 		Parser.const(

--- a/package/HTTP.roc
+++ b/package/HTTP.roc
@@ -154,8 +154,10 @@ request_uri =
 		.one_or_more()
 		.map(String.str_from_utf8)
 
+sp : Parser(String.Utf8, U8)
 sp = String.codeunit(' ')
 
+crlf : Parser(String.Utf8, Str)
 crlf = String.string("\r\n")
 
 http_version : Parser(String.Utf8, HTTP.HttpVersion)

--- a/package/Markdown.roc
+++ b/package/Markdown.roc
@@ -19,10 +19,7 @@ Markdown := [
 		inspect_markdown(node)
 	}
 
-	is_eq : Markdown, Markdown -> Bool
-	is_eq = |left, right| {
-		markdown_is_eq(left, right)
-	}
+	is_eq : _
 
 	to_debug_str : Markdown -> Str
 	to_debug_str = |node| {
@@ -45,10 +42,7 @@ Markdown := [
 			level_to_str(level)
 		}
 
-		is_eq : Level, Level -> Bool
-		is_eq = |left, right| {
-			level_is_eq(left, right)
-		}
+		is_eq : _
 	}
 
 	ListKind := [
@@ -65,10 +59,7 @@ Markdown := [
 			list_kind_to_str(kind)
 		}
 
-		is_eq : ListKind, ListKind -> Bool
-		is_eq = |left, right| {
-			list_kind_is_eq(left, right)
-		}
+		is_eq : _
 	}
 
 	TaskState := [
@@ -86,10 +77,7 @@ Markdown := [
 			task_state_to_str(task)
 		}
 
-		is_eq : TaskState, TaskState -> Bool
-		is_eq = |left, right| {
-			task_state_is_eq(left, right)
-		}
+		is_eq : _
 	}
 
 	Alignment := [
@@ -108,10 +96,7 @@ Markdown := [
 			alignment_to_str(alignment)
 		}
 
-		is_eq : Alignment, Alignment -> Bool
-		is_eq = |left, right| {
-			alignment_is_eq(left, right)
-		}
+		is_eq : _
 	}
 
 	LinkTarget : {
@@ -135,10 +120,7 @@ Markdown := [
 			inspect_inline(inline)
 		}
 
-		is_eq : Inline, Inline -> Bool
-		is_eq = |left, right| {
-			inline_is_eq(left, right)
-		}
+		is_eq : _
 	}
 
 	all : Parser(String.Utf8, List(Markdown))
@@ -264,44 +246,6 @@ inspect_markdown = |node| {
 	}
 }
 
-markdown_is_eq : Markdown, Markdown -> Bool
-markdown_is_eq = |left, right| {
-	match { left, right } {
-		{ left: Heading(l), right: Heading(r) } =>
-			l.level == r.level and l.content == r.content
-
-		{ left: Paragraph(l), right: Paragraph(r) } =>
-			l == r
-
-		{ left: Blockquote(l), right: Blockquote(r) } =>
-			l == r
-
-		{ left: ListBlock(l), right: ListBlock(r) } =>
-			l.kind == r.kind and l.loose == r.loose and l.items == r.items
-
-		{ left: Code(l), right: Code(r) } =>
-			l.info == r.info and l.pre == r.pre
-
-		{ left: ThematicBreak, right: ThematicBreak } =>
-			Bool.True
-
-		{ left: Table(l), right: Table(r) } =>
-			l.header == r.header and l.align == r.align and l.rows == r.rows
-
-		{ left: HtmlBlock(l), right: HtmlBlock(r) } =>
-			l == r
-
-		{ left: Frontmatter(l), right: Frontmatter(r) } =>
-			l.raw == r.raw
-
-		{ left: TODO(l), right: TODO(r) } =>
-			l == r
-
-		_ =>
-			Bool.False
-	}
-}
-
 inspect_level : Markdown.Level -> Str
 inspect_level = |level| {
 	match level {
@@ -326,11 +270,6 @@ level_to_str = |level| {
 	}
 }
 
-level_is_eq : Markdown.Level, Markdown.Level -> Bool
-level_is_eq = |left, right| {
-	level_to_str(left) == level_to_str(right)
-}
-
 inspect_list_kind : Markdown.ListKind -> Str
 inspect_list_kind = |kind| {
 	match kind {
@@ -353,20 +292,6 @@ list_kind_to_str = |kind| {
 	}
 }
 
-list_kind_is_eq : Markdown.ListKind, Markdown.ListKind -> Bool
-list_kind_is_eq = |left, right| {
-	match { left, right } {
-		{ left: Unordered, right: Unordered } =>
-			Bool.True
-
-		{ left: Ordered(l), right: Ordered(r) } =>
-			l.start == r.start
-
-		_ =>
-			Bool.False
-	}
-}
-
 inspect_task_state : Markdown.TaskState -> Str
 inspect_task_state = |task| {
 	match task {
@@ -383,11 +308,6 @@ task_state_to_str = |task| {
 		Unchecked => "unchecked"
 		Checked => "checked"
 	}
-}
-
-task_state_is_eq : Markdown.TaskState, Markdown.TaskState -> Bool
-task_state_is_eq = |left, right| {
-	task_state_to_str(left) == task_state_to_str(right)
 }
 
 inspect_alignment : Markdown.Alignment -> Str
@@ -408,11 +328,6 @@ alignment_to_str = |alignment| {
 		Center => "center"
 		Right => "right"
 	}
-}
-
-alignment_is_eq : Markdown.Alignment, Markdown.Alignment -> Bool
-alignment_is_eq = |left, right| {
-	alignment_to_str(left) == alignment_to_str(right)
 }
 
 inspect_inline : Markdown.Inline -> Str
@@ -444,41 +359,6 @@ inspect_inline = |inline| {
 
 		HtmlInline(raw) =>
 			"HtmlInline(${Str.inspect(raw)})"
-	}
-}
-
-inline_is_eq : Markdown.Inline, Markdown.Inline -> Bool
-inline_is_eq = |left, right| {
-	match { left, right } {
-		{ left: Text(l), right: Text(r) } =>
-			l == r
-
-		{ left: Strong(l), right: Strong(r) } =>
-			l == r
-
-		{ left: Emphasis(l), right: Emphasis(r) } =>
-			l == r
-
-		{ left: Strikethrough(l), right: Strikethrough(r) } =>
-			l == r
-
-		{ left: InlineCode(l), right: InlineCode(r) } =>
-			l == r
-
-		{ left: Link(l), right: Link(r) } =>
-			l.label == r.label and l.target == r.target
-
-		{ left: Image(l), right: Image(r) } =>
-			l.alt == r.alt and l.target == r.target
-
-		{ left: HardBreak, right: HardBreak } =>
-			Bool.True
-
-		{ left: HtmlInline(l), right: HtmlInline(r) } =>
-			l == r
-
-		_ =>
-			Bool.False
 	}
 }
 
@@ -1064,6 +944,7 @@ can_be_setext_heading_text = |line, min_indent| {
 	(!line_is_blank(line)) and line_indent(line) >= min_indent and !is_block_start(line, min_indent)
 }
 
+inline_heading : Parser(String.Utf8, Markdown)
 inline_heading =
 	Parser.const(
 		|level| {
@@ -1086,6 +967,7 @@ inline_heading =
 		)
 		.keep(Parser.chomp_while(not_end_of_line).map(String.str_from_utf8))
 
+two_line_heading_level_one : Parser(String.Utf8, Markdown)
 two_line_heading_level_one =
 	Parser.const(
 		|str| {
@@ -1103,6 +985,7 @@ two_line_heading_level_one =
 			),
 		)
 
+two_line_heading_level_two : Parser(String.Utf8, Markdown)
 two_line_heading_level_two =
 	Parser.const(
 		|str| {
@@ -2282,8 +2165,10 @@ is_escapable_inline_byte = |byte| {
 		or byte == '|'
 }
 
+end_of_line : Parser(String.Utf8, Str)
 end_of_line = Parser.one_of([String.string("\n"), String.string("\r\n")])
 
+not_end_of_line : U8 -> Bool
 not_end_of_line = |b| {
 	b != '\n' and b != '\r'
 }

--- a/package/Markdown.roc
+++ b/package/Markdown.roc
@@ -1,7 +1,11 @@
 import Parser
 import String
 
-# # Content values
+## Markdown syntax tree and parsers for documents and inline content.
+##
+## The block parser preserves frontmatter, headings, paragraphs, blockquotes,
+## lists, code blocks, thematic breaks, tables, and raw HTML. Inline parsing
+## supports emphasis, links, images, code, hard breaks, and raw HTML.
 Markdown := [
 	Heading({ level : Markdown.Level, content : List(Markdown.Inline) }),
 	Paragraph(List(Markdown.Inline)),
@@ -14,96 +18,118 @@ Markdown := [
 	Frontmatter({ raw : Str }),
 	TODO(Str),
 ].{
+	## Render a Markdown block in Roc source-like notation for inspection.
 	to_inspect : Markdown -> Str
 	to_inspect = |node| {
 		inspect_markdown(node)
 	}
 
+	## Compare two Markdown syntax trees structurally.
 	is_eq : _
 
+	## Render a Markdown block as a stable debug string.
 	to_debug_str : Markdown -> Str
 	to_debug_str = |node| {
 		inspect_markdown(node)
 	}
 
+	## Render an inline node as a stable debug string.
 	inline_to_debug_str : Markdown.Inline -> Str
 	inline_to_debug_str = |inline| {
 		inspect_inline(inline)
 	}
 
+	## Heading levels from one through six.
 	Level := [One, Two, Three, Four, Five, Six].{
+		## Render a heading level for inspection.
 		to_inspect : Level -> Str
 		to_inspect = |level| {
 			inspect_level(level)
 		}
 
+		## Convert a heading level to its decimal representation.
 		to_str : Level -> Str
 		to_str = |level| {
 			level_to_str(level)
 		}
 
+		## Compare two heading levels.
 		is_eq : _
 	}
 
+	## The marker and starting number of a Markdown list.
 	ListKind := [
 		Unordered,
 		Ordered({ start : U64 }),
 	].{
+		## Render a list kind for inspection.
 		to_inspect : ListKind -> Str
 		to_inspect = |kind| {
 			inspect_list_kind(kind)
 		}
 
+		## Convert a list kind to a compact string.
 		to_str : ListKind -> Str
 		to_str = |kind| {
 			list_kind_to_str(kind)
 		}
 
+		## Compare two list kinds structurally.
 		is_eq : _
 	}
 
+	## Whether a list item is a task and, if so, whether it is checked.
 	TaskState := [
 		NoTask,
 		Unchecked,
 		Checked,
 	].{
+		## Render a task state for inspection.
 		to_inspect : TaskState -> Str
 		to_inspect = |task| {
 			inspect_task_state(task)
 		}
 
+		## Convert a task state to a compact string.
 		to_str : TaskState -> Str
 		to_str = |task| {
 			task_state_to_str(task)
 		}
 
+		## Compare two task states.
 		is_eq : _
 	}
 
+	## Column alignment declared by a Markdown table delimiter row.
 	Alignment := [
 		Default,
 		Left,
 		Center,
 		Right,
 	].{
+		## Render a table alignment for inspection.
 		to_inspect : Alignment -> Str
 		to_inspect = |alignment| {
 			inspect_alignment(alignment)
 		}
 
+		## Convert a table alignment to a compact string.
 		to_str : Alignment -> Str
 		to_str = |alignment| {
 			alignment_to_str(alignment)
 		}
 
+		## Compare two table alignments.
 		is_eq : _
 	}
 
+	## Destination and optional title of a link or image.
 	LinkTarget : {
 		href : Str,
 		title : [Some(Str), None],
 	}
 
+	## Inline Markdown syntax nodes.
 	Inline := [
 		Text(Str),
 		Strong(List(Inline)),
@@ -115,20 +141,25 @@ Markdown := [
 		HardBreak,
 		HtmlInline(Str),
 	].{
+		## Render an inline node in Roc source-like notation for inspection.
 		to_inspect : Inline -> Str
 		to_inspect = |inline| {
 			inspect_inline(inline)
 		}
 
+		## Compare two inline syntax trees structurally.
 		is_eq : _
 	}
 
+	## Parse a complete Markdown document into block nodes.
 	all : Parser(String.Utf8, List(Markdown))
 	all = parse_all
 
+	## Parse inline Markdown content.
 	inlines : Parser(String.Utf8, List(Inline))
 	inlines = parse_inlines_parser
 
+	## Parse an ATX or Setext heading.
 	heading : Parser(String.Utf8, Markdown)
 	heading =
 		Parser.one_of(
@@ -139,6 +170,7 @@ Markdown := [
 			],
 		)
 
+	## Parse an inline link with a destination in parentheses.
 	link : Parser(String.Utf8, Inline)
 	link =
 		Parser.const(
@@ -166,6 +198,7 @@ Markdown := [
 			)
 			.skip(String.codeunit(')'))
 
+	## Parse an inline image with a destination in parentheses.
 	image : Parser(String.Utf8, Inline)
 	image =
 		Parser.const(
@@ -193,6 +226,7 @@ Markdown := [
 			)
 			.skip(String.codeunit(')'))
 
+	## Parse a fenced code block delimited by triple backticks.
 	code : Parser(String.Utf8, Markdown)
 	code =
 		Parser.const(|info| |pre| Code({ info: info, pre: pre }))

--- a/package/Parser.roc
+++ b/package/Parser.roc
@@ -1,102 +1,97 @@
-# # # Parser
-# #
-# # This package implements a basic [Parser Combinator](https://en.wikipedia.org/wiki/Parser_combinator)
-# # for Roc which is useful for transforming input into a more useful structure.
-# #
-# # ## Example
-# # For example, say we wanted to parse the following string from `in` to `out`:
-# # ```roc
-# # input = "Game 1: 3 blue, 4 red; 1 red, 2 green, 6 blue; 2 green"
-# # output =
-# #     {
-# #         id: 1,
-# #         requirements: [
-# #             [Blue(3), Red(4)],
-# #             [Red(1), Green(2), Blue(6)],
-# #             [Green(2)],
-# #         ]
-# #     }
-# # ```
-# # We could do this using the following:
-# # ```roc
-# # Requirement : [Green(U64), Red(U64), Blue(U64)]
-# # RequirementSet : List(Requirement)
-# # Game : { id : U64, requirements : List(RequirementSet) }
-# #
-# # parse_game : Str -> Try(Game, [ParsingError])
-# # parse_game = |s| {
-# #     green = const(|x|Green(x)).keep(digits).skip(string(" green"))
-# #     red = const(|x|Red(x)).keep(digits).skip(string(" red"))
-# #     blue = const(|x|Blue(x)).keep(digits).skip(string(" blue"))
-# #
-# #     requirement_set : Parser(_, RequirementSet)
-# #     requirement_set = one_of([green, red, blue]).sep_by(string(", "))
-# #
-# #     requirements : Parser(_, List(RequirementSet))
-# #     requirements = requirement_set.sep_by(string("; "))
-# #
-# #     game : Parser(_, Game)
-# #     game = {
-# #         const(|id| |r| { id, requirements: r })
-# #         .skip(string("Game "))
-# #         .keep(digits)
-# #         .skip(string(": "))
-# #         .keep(requirements)
-# #     }
-# #
-# #     match String.parse_str(game, s) {
-# #         Ok(g) => Ok(g)
-# #         Err(ParsingFailure(_)) | Err(ParsingIncomplete(_)) => Err(ParsingError)
-# #     }
-# # }
-# # ```
-
-# # Opaque type for a parser that will try to parse an `a` from an `input`.
-# #
-# # As such, a parser can be considered a recipe for a function of the type
-# # ```roc
-# # input -> Try({val: a, input: input}, [ParsingFailure(Str)])
-# # ```
-# #
-# # How a parser is _actually_ implemented internally is not important
-# # and this might change between versions;
-# # for instance to improve efficiency or error messages on parsing failures.
+## Generic [parser combinators](https://en.wikipedia.org/wiki/Parser_combinator)
+## for transforming input into structured values.
+##
+## Example:
+## Parse the following string from `input` into the structured `output` value:
+## ```roc
+## input = "Game 1: 3 blue, 4 red; 1 red, 2 green, 6 blue; 2 green"
+## output =
+##     {
+##         id: 1,
+##         requirements: [
+##             [Blue(3), Red(4)],
+##             [Red(1), Green(2), Blue(6)],
+##             [Green(2)],
+##         ]
+##     }
+## ```
+## We could do this using the following:
+## ```roc
+## Requirement : [Green(U64), Red(U64), Blue(U64)]
+## RequirementSet : List(Requirement)
+## Game : { id : U64, requirements : List(RequirementSet) }
+##
+## parse_game : Str -> Try(Game, [ParsingError])
+## parse_game = |s| {
+##     green = const(|x|Green(x)).keep(digits).skip(string(" green"))
+##     red = const(|x|Red(x)).keep(digits).skip(string(" red"))
+##     blue = const(|x|Blue(x)).keep(digits).skip(string(" blue"))
+##
+##     requirement_set : Parser(_, RequirementSet)
+##     requirement_set = one_of([green, red, blue]).sep_by(string(", "))
+##
+##     requirements : Parser(_, List(RequirementSet))
+##     requirements = requirement_set.sep_by(string("; "))
+##
+##     game : Parser(_, Game)
+##     game = {
+##         const(|id| |r| { id, requirements: r })
+##         .skip(string("Game "))
+##         .keep(digits)
+##         .skip(string(": "))
+##         .keep(requirements)
+##     }
+##
+##     match String.parse_str(game, s) {
+##         Ok(g) => Ok(g)
+##         Err(ParsingFailure(_)) | Err(ParsingIncomplete(_)) => Err(ParsingError)
+##     }
+## }
+## ```
+##
+## Opaque type for a parser that will try to parse an `a` from an `input`.
+##
+## As such, a parser can be considered a recipe for a function of the type
+## ```roc
+## input -> Try({val: a, input: input}, [ParsingFailure(Str)])
+## ```
+##
+## The representation is internal and may change to improve efficiency or error messages.
 Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 
-	# # ```roc
-	# # ParseResult(input, a) : Try({ val : a, input : input }, [ParsingFailure(Str)])
-	# # ```
+	## The result of parsing part of an input: either a value and the remaining
+	## input, or a `ParsingFailure` message.
 	ParseResult(input, a) : Try({ val : a, input : input }, [ParsingFailure(Str)])
 
-	# # Write a custom parser without using provided combintors.
+	## Write a custom parser without using the provided combinators.
 	build_primitive_parser : (input -> ParseResult(input, a)) -> Parser(input, a)
 	build_primitive_parser = |fun| {
 		{ fun }
 	}
 
-	# # Most general way of running a parser.
-	# #
-	# # Can be thought of as turning the recipe of a parser into its actual parsing function
-	# # and running this function on the given input.
-	# #
-	# # Moat parsers consume part of `input` when they succeed. This allows you to string parsers
-	# # together that run one after the other. The part of the input that the first
-	# # parser did not consume, is used by the next parser.
-	# # This is why a parser returns on success both the resulting value and the leftover part of the input.
-	# #
-	# # This is mostly useful when creating your own internal parsing building blocks.
+	## Most general way of running a parser.
+	##
+	## Can be thought of as turning the recipe of a parser into its actual parsing function
+	## and running this function on the given input.
+	##
+	## Most parsers consume part of `input` when they succeed. This allows you to string parsers
+	## together that run one after the other. The part of the input that the first
+	## parser did not consume, is used by the next parser.
+	## This is why a parser returns on success both the resulting value and the leftover part of the input.
+	##
+	## This is mostly useful when creating your own internal parsing building blocks.
 	parse_partial : Parser(input, a), input -> ParseResult(input, a)
 	parse_partial = |{ fun }, input| {
 		fun(input)
 	}
 
-	# # Runs a parser on the given input, expecting it to fully consume the input
-	# #
-	# # The `input -> Bool` parameter is used to check whether parsing has 'completed',
-	# # i.e. how to determine if all of the input has been consumed.
-	# #
-	# # For most input types, a parsing run that leaves some unparsed input behind
-	# # should be considered an error.
+	## Runs a parser on the given input, expecting it to fully consume the input
+	##
+	## The `input -> Bool` parameter is used to check whether parsing has 'completed',
+	## i.e. how to determine if all of the input has been consumed.
+	##
+	## For most input types, a parsing run that leaves some unparsed input behind
+	## should be considered an error.
 	parse : Parser(input, a), input, (input -> Bool) -> Try(a, [ParsingFailure(Str), ParsingIncomplete(input)])
 	parse = |parser, input, is_parsing_completed| {
 		match parser.parse_partial(input) {
@@ -113,11 +108,11 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		}
 	}
 
-	# # Parser that can never succeed, regardless of the given input.
-	# # It will always fail with the given error message.
-	# #
-	# # This is mostly useful as a 'base case' if all other parsers
-	# # in a `one_of` or `alt` have failed, to provide some more descriptive error message.
+	## Parser that can never succeed, regardless of the given input.
+	## It will always fail with the given error message.
+	##
+	## This is mostly useful as a 'base case' if all other parsers
+	## in a `one_of` or `alt` have failed, to provide some more descriptive error message.
 	fail : Str -> Parser(_, _)
 	fail = |msg| {
 		build_primitive_parser(
@@ -127,18 +122,18 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
-	# # Parser that will always produce the given `a`, without looking at the actual input.
-	# # This is useful as a basic building block, especially in combination with
-	# # `map` and `apply`.
-	# # ```roc
-	# # parse_u32 : Parser(List(U8), U32)
-	# # parse_u32 = {
-	# #     const(U64.to_u32_wrap)  # TODO: U64.to_u32_try would be better?
-	# #     .keep(String.digits)
-	# # }
-	# #
-	# # expect String.parse_str(parse_u32, "123") == Ok(123.U32)
-	# # ```
+	## Parser that will always produce the given `a`, without looking at the actual input.
+	## This is useful as a basic building block, especially in combination with
+	## `map` and `apply`.
+	## ```roc
+	## parse_u32 : Parser(List(U8), U32)
+	## parse_u32 = {
+	##     const(U64.to_u32_wrap)  # TODO: U64.to_u32_try would be better?
+	##     .keep(String.digits)
+	## }
+	##
+	## expect String.parse_str(parse_u32, "123") == Ok(123.U32)
+	## ```
 	const : a -> Parser(_, a)
 	const = |val| {
 		build_primitive_parser(
@@ -148,7 +143,7 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
-	# # Try the `first` parser and (only) if it fails, try the `second` parser as fallback.
+	## Try the `first` parser and (only) if it fails, try the `second` parser as fallback.
 	alt : Parser(input, a), Parser(input, a) -> Parser(input, a)
 	alt = |first, second| {
 		build_primitive_parser(
@@ -168,29 +163,29 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
-	# # Runs a parser building a function, then a parser building a value,
-	# # and finally returns the result of calling the function with the value.
-	# #
-	# # This is useful if you are building up a structure that requires more parameters
-	# # than there are variants of `map`, `map2`, `map3` etc. for.
-	# #
-	# # For instance, the following two are the same:
-	# # ```roc
-	# # const(|x| |y| |z| Triple(x, y, z))
-	# # .map3(String.digits, String.digits, String.digits)
-	# #
-	# # const(|x| |y| |z| Triple(x, y, z))
-	# # .apply(String.digits)
-	# # .apply(String.digits)
-	# # .apply(String.digits)
-	# # ```
-	# # Indeed, this is how `map`, `map2`, `map3` etc. are implemented under the hood.
-	# #
-	# # # Currying
-	# # Be aware that when using `apply`, you need to explicitly 'curry' the parameters to the construction function.
-	# # This means that instead of writing `|x, y, z| ...`
-	# # you'll need to write `|x| |y| |z| ...`.
-	# # This is because the parameters of the function will be applied one by one as parsing continues.
+	## Runs a parser building a function, then a parser building a value,
+	## and finally returns the result of calling the function with the value.
+	##
+	## This is useful if you are building up a structure that requires more parameters
+	## than there are variants of `map`, `map2`, `map3` etc. for.
+	##
+	## For instance, the following two are the same:
+	## ```roc
+	## const(|x| |y| |z| Triple(x, y, z))
+	## .map3(String.digits, String.digits, String.digits)
+	##
+	## const(|x| |y| |z| Triple(x, y, z))
+	## .apply(String.digits)
+	## .apply(String.digits)
+	## .apply(String.digits)
+	## ```
+	## Indeed, this is how `map`, `map2`, `map3` etc. are implemented under the hood.
+	##
+	## Currying:
+	## Be aware that when using `apply`, you need to explicitly 'curry' the parameters to the construction function.
+	## This means that instead of writing `|x, y, z| ...`
+	## you'll need to write `|x| |y| |z| ...`.
+	## This is because the parameters of the function will be applied one by one as parsing continues.
 	apply : Parser(input, (a -> b)), Parser(input, a) -> Parser(input, b)
 	apply = |fun_parser, val_parser| {
 		combined = |input| {
@@ -205,21 +200,21 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		build_primitive_parser(combined)
 	}
 
-	# # Try a list of parsers in turn, until one of them succeeds.
-	# # ```roc
-	# # color : Parser(Utf8, [Red, Green, Blue])
-	# # color = {
-	# #     one_of(
-	# #         [
-	# #             const(Red).skip(string("red")),
-	# #             const(Green).skip(string("green")),
-	# #             const(Blue).skip(string("blue")),
-	# #         ],
-	# #     )
-	# # }
-	# #
-	# # expect String.parse_str(color, "green") == Ok(Green)
-	# # ```
+	## Try a list of parsers in turn, until one of them succeeds.
+	## ```roc
+	## color : Parser(Utf8, [Red, Green, Blue])
+	## color = {
+	##     one_of(
+	##         [
+	##             const(Red).skip(string("red")),
+	##             const(Green).skip(string("green")),
+	##             const(Blue).skip(string("blue")),
+	##         ],
+	##     )
+	## }
+	##
+	## expect String.parse_str(color, "green") == Ok(Green)
+	## ```
 	one_of : List(Parser(input, a)) -> Parser(input, a)
 	one_of = |parsers| {
 		parsers.fold_rev(
@@ -230,16 +225,16 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
-	# # Transforms the result of parsing into something else,
-	# # using the given transformation function.
+	## Transforms the result of parsing into something else,
+	## using the given transformation function.
 	map : Parser(input, a), (a -> b) -> Parser(input, b)
 	map = |simple_parser, transform| {
 		const(transform)
 			.apply(simple_parser)
 	}
 
-	# # Transforms the result of parsing into something else,
-	# # using the given two-parameter transformation function.
+	## Transforms the result of parsing into something else,
+	## using the given two-parameter transformation function.
 	map2 : Parser(input, a), Parser(input, b), (a, b -> c) -> Parser(input, c)
 	map2 = |parser_a, parser_b, transform| {
 		const(
@@ -253,11 +248,11 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 			.apply(parser_b)
 	}
 
-	# # Transforms the result of parsing into something else,
-	# # using the given three-parameter transformation function.
-	# #
-	# # If you need transformations with more inputs,
-	# # take a look at `apply`.
+	## Transforms the result of parsing into something else,
+	## using the given three-parameter transformation function.
+	##
+	## If you need transformations with more inputs,
+	## take a look at `apply`.
 	map3 : Parser(input, a), Parser(input, b), Parser(input, c), (a, b, c -> d) -> Parser(input, d)
 	map3 = |parser_a, parser_b, parser_c, transform| {
 		const(
@@ -274,25 +269,25 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 			.apply(parser_c)
 	}
 
-	# # Removes a layer of `Result` from running the parser.
-	# #
-	# # Use this to map functions that return a result over the parser,
-	# # where errors are turned into `ParsingFailure`s.
-	# #
-	# # ```roc
-	# # # Parse a number from a List(U8)
-	# # u64 : Parser(Utf8, U64)
-	# # u64 =
-	# #     string
-	# #     .map(
-	# #         |val|
-	# #             match U64.from_str(val) {
-	# #                 Ok(num) => Ok(num)
-	# #                 Err(_) => Err("${val} is not a U64."),
-	# #             }
-	# #     )
-	# #     .flatten()
-	# # ```
+	## Removes a layer of `Result` from running the parser.
+	##
+	## Use this to map functions that return a result over the parser,
+	## where errors are turned into `ParsingFailure`s.
+	##
+	## ```roc
+	## # Parse a number from a List(U8)
+	## u64 : Parser(Utf8, U64)
+	## u64 =
+	##     string
+	##     .map(
+	##         |val|
+	##             match U64.from_str(val) {
+	##                 Ok(num) => Ok(num)
+	##                 Err(_) => Err("${val} is not a U64."),
+	##             }
+	##     )
+	##     .flatten()
+	## ```
 	flatten : Parser(input, Try(a, Str)) -> Parser(input, a)
 	flatten = |parser| {
 		build_primitive_parser(
@@ -308,21 +303,23 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
-	# # Runs a parser lazily
-	# #
-	# # This is (only) useful when dealing with a recursive structure.
-	# # For instance, consider a type `Comment : { message: String, responses: List(Comment) }`.
-	# # Without `lazy`, you would ask the compiler to build an infinitely deep parser.
-	# # (Resulting in a compiler error.)
-	# #
+	## Runs a parser lazily
+	##
+	## This is (only) useful when dealing with a recursive structure.
+	## For instance, consider a type `Comment : { message: String, responses: List(Comment) }`.
+	## Without `lazy`, you would ask the compiler to build an infinitely deep parser.
+	## (Resulting in a compiler error.)
+	##
+	## Mutually recursive top-level parser values currently require a lower-level
+	## workaround because of [roc-lang/roc#10098](https://github.com/roc-lang/roc/issues/10098).
 	lazy : ({} -> Parser(input, a)) -> Parser(input, a)
 	lazy = |thunk| {
 		const({})
 			->and_then(thunk)
 	}
 
-	# # A parser that tries to apply the given parser and returns
-	# # Err(Nothing) if that parser fails.
+	## A parser that tries to apply the given parser and returns
+	## Err(Nothing) if that parser fails.
 	maybe : Parser(input, a) -> Parser(input, Try(a, [Nothing]))
 	maybe = |parser| {
 		parser
@@ -334,8 +331,8 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 			.alt(const(Err(Nothing)))
 	}
 
-	# # A parser which runs the element parser *zero* or more times on the input,
-	# # returning a list containing all the parsed elements.
+	## A parser which runs the element parser *zero* or more times on the input,
+	## returning a list containing all the parsed elements.
 	many : Parser(input, a) -> Parser(input, List(a))
 	many = |parser| {
 		build_primitive_parser(
@@ -345,10 +342,10 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
-	# # A parser which runs the element parser *one* or more times on the input,
-	# # returning a list containing all the parsed elements.
-	# #
-	# # Also see [Parser.many].
+	## A parser which runs the element parser *one* or more times on the input,
+	## returning a list containing all the parsed elements.
+	##
+	## Also see [Parser.many].
 	one_or_more : Parser(input, a) -> Parser(input, List(a))
 	one_or_more = |parser| {
 		const(
@@ -362,14 +359,14 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 			.apply(many(parser))
 	}
 
-	# # Runs a parser for an 'opening' delimiter, then your main parser, then the 'closing' delimiter,
-	# # and only returns the result of your main parser.
-	# #
-	# # Useful to recognize structures surrounded by delimiters (like braces, parentheses, quotes, etc.)
-	# #
-	# # ```roc
-	# # between_braces = |parser| parser.between(scalar('['), scalar(']'))
-	# # ```
+	## Runs a parser for an 'opening' delimiter, then your main parser, then the 'closing' delimiter,
+	## and only returns the result of your main parser.
+	##
+	## Useful to recognize structures surrounded by delimiters (like braces, parentheses, quotes, etc.)
+	##
+	## ```roc
+	## between_braces = |parser| parser.between(scalar('['), scalar(']'))
+	## ```
 	between : Parser(input, a), Parser(input, open), Parser(input, close) -> Parser(input, a)
 	between = |parser, open, close| {
 		const(
@@ -386,6 +383,8 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 			.apply(close)
 	}
 
+	## Parse one or more values separated by `separator`.
+	## The separators are consumed and omitted from the result.
 	sep_by1 : Parser(input, a), Parser(input, sep) -> Parser(input, List(a))
 	sep_by1 = |parser, separator| {
 		parser_followed_by_sep = 
@@ -410,20 +409,23 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 			.apply(many(parser_followed_by_sep))
 	}
 
+	## Parse zero or more values separated by `separator`.
+	## The separators are consumed and omitted from the result.
+	##
+	## ```roc
+	## parse_numbers : Parser(List(U8), List(U64))
+	## parse_numbers = digits.sep_by(codeunit(','))
+	##
+	## expect String.parse_str(parse_numbers, "1,2,3") == Ok([1, 2, 3])
+	## ```
 	sep_by : Parser(input, a), Parser(input, sep) -> Parser(input, List(a))
-
-	# # ```roc
-	# # parse_numbers : Parser(List(U8), List(U64))
-	# # parse_numbers = digits.sep_by(codeunit(','))
-	# #
-	# # expect String.parse_str(parse_numbers, "1,2,3") == Ok([1, 2, 3])
-	# # ```
 	sep_by = |parser, separator| {
 		parser
 			.sep_by1(separator)
 			.alt(const([]))
 	}
 
+	## Discard a parser's value while preserving how much input it consumes.
 	ignore : Parser(input, a) -> Parser(input, {})
 	ignore = |parser| {
 		parser.map(
@@ -433,6 +435,8 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
+	## Run a parser producing a function, then a parser producing its argument,
+	## and return the function result.
 	keep : Parser(input, (a -> b)), Parser(input, a) -> Parser(input, b)
 	keep = |fun_parser, val_parser| {
 		build_primitive_parser(
@@ -452,6 +456,7 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
+	## Run two parsers in sequence, discarding the second parser's value.
 	skip : Parser(input, a), Parser(input, _) -> Parser(input, a)
 	skip = |fun_parser, skip_parser| {
 		build_primitive_parser(
@@ -469,37 +474,37 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
-	# # Match zero or more codeunits until the it reaches the given codeunit.
-	# # The given codeunit is not included in the match.
-	# #
-	# # This can be used with [Parser.skip] to ignore text.
-	# #
-	# # ```roc
-	# # ignore_text : Parser(List(U8), U64)
-	# # ignore_text =
-	# #     const(|d| d)
-	# #     .skip(chomp_until(':'))
-	# #     .skip(codeunit(':'))
-	# #     .keep(digits)
-	# #
-	# # expect String.parse_str(ignore_text, "ignore preceding text:123") == Ok(123)
-	# # ```
-	# #
-	# # This can be used with [Parser.keep] to capture a list of `U8` codeunits.
-	# #
-	# # ```roc
-	# # capture_text : Parser(List(U8), List(U8))
-	# # capture_text =
-	# #     const(|codeunits| codeunits)
-	# #     .keep(chomp_until(':'))
-	# #     .skip(codeunit(':'))
-	# #
-	# # expect String.parse_str(capture_text, "Roc:") == Ok(['R', 'o', 'c'])
-	# # ```
-	# #
-	# # Use [String.str_from_utf8] to turn the results into a `Str`.
-	# #
-	# # Also see [Parser.chomp_while].
+	## Match zero or more codeunits until it reaches the given codeunit.
+	## The given codeunit is not included in the match.
+	##
+	## This can be used with [Parser.skip] to ignore text.
+	##
+	## ```roc
+	## ignore_text : Parser(List(U8), U64)
+	## ignore_text =
+	##     const(|d| d)
+	##     .skip(chomp_until(':'))
+	##     .skip(codeunit(':'))
+	##     .keep(digits)
+	##
+	## expect String.parse_str(ignore_text, "ignore preceding text:123") == Ok(123)
+	## ```
+	##
+	## This can be used with [Parser.keep] to capture a list of `U8` codeunits.
+	##
+	## ```roc
+	## capture_text : Parser(List(U8), List(U8))
+	## capture_text =
+	##     const(|codeunits| codeunits)
+	##     .keep(chomp_until(':'))
+	##     .skip(codeunit(':'))
+	##
+	## expect String.parse_str(capture_text, "Roc:") == Ok(['R', 'o', 'c'])
+	## ```
+	##
+	## Use [String.str_from_utf8] to turn the results into a `Str`.
+	##
+	## Also see [Parser.chomp_while].
 	chomp_until : a -> Parser(List(a), List(a)) where [a.is_eq : a, a -> Bool]
 	chomp_until = |char| {
 		build_primitive_parser(
@@ -519,38 +524,38 @@ Parser(input, a) :: { fun : input -> Parser.ParseResult(input, a) }.{
 		)
 	}
 
-	# # Match zero or more codeunits until the check returns false.
-	# # The codeunit that returned false is not included in the match.
-	# # Note: a chompWhile parser always succeeds!
-	# #
-	# # This can be used with [Parser.skip] to ignore text.
-	# # This is useful for chomping whitespace or variable names.
-	# #
-	# # ```
-	# # ignore_numbers : Parser(List(U8), Str)
-	# # ignore_numbers =
-	# #     const(|str| str)
-	# #     .skip(chomp_while(|b| b >= '0' && b <= '9'))
-	# #     .keep(string("TEXT"))
-	# #
-	# # expect String.parse_str(ignore_numbers, "0123456789876543210TEXT") == Ok("TEXT")
-	# # ```
-	# #
-	# # This can be used with [Parser.keep] to capture a list of `U8` codeunits.
-	# #
-	# # ```
-	# # capture_numbers : Parser(List(U8), List(U8))
-	# # capture_numbers =
-	# #     const(|codeunits| codeunits)
-	# #     .keep(chomp_while(|b| b >= '0' && b <= '9'))
-	# #     .skip(string("TEXT"))
-	# #
-	# # expect String.parse_str(capture_numbers, "123TEXT") == Ok(['1', '2', '3'])
-	# # ```
-	# #
-	# # Use [String.str_from_utf8] to turn the results into a `Str`.
-	# #
-	# # Also see [Parser.chomp_until].
+	## Match zero or more codeunits until the check returns false.
+	## The codeunit that returned false is not included in the match.
+	## Note: a `chomp_while` parser always succeeds!
+	##
+	## This can be used with [Parser.skip] to ignore text.
+	## This is useful for chomping whitespace or variable names.
+	##
+	## ```
+	## ignore_numbers : Parser(List(U8), Str)
+	## ignore_numbers =
+	##     const(|str| str)
+	##     .skip(chomp_while(|b| b >= '0' && b <= '9'))
+	##     .keep(string("TEXT"))
+	##
+	## expect String.parse_str(ignore_numbers, "0123456789876543210TEXT") == Ok("TEXT")
+	## ```
+	##
+	## This can be used with [Parser.keep] to capture a list of `U8` codeunits.
+	##
+	## ```
+	## capture_numbers : Parser(List(U8), List(U8))
+	## capture_numbers =
+	##     const(|codeunits| codeunits)
+	##     .keep(chomp_while(|b| b >= '0' && b <= '9'))
+	##     .skip(string("TEXT"))
+	##
+	## expect String.parse_str(capture_numbers, "123TEXT") == Ok(['1', '2', '3'])
+	## ```
+	##
+	## Use [String.str_from_utf8] to turn the results into a `Str`.
+	##
+	## Also see [Parser.chomp_until].
 	chomp_while : (a -> Bool) -> Parser(List(a), List(a))
 	chomp_while = |check| {
 		build_primitive_parser(

--- a/package/String.roc
+++ b/package/String.roc
@@ -1,13 +1,13 @@
 import Parser
 
+## Parsers and helpers specialized to UTF-8 byte lists and Roc `Str` values.
 String :: {}.{
 
-	## ```
-	## Utf8 : List U8
-	## ```
+	## UTF-8 input represented as a list of bytes.
 	Utf8 : List(U8)
 
-	## Parse a `Str` using a [Parser]
+	## Parse a `Str` using a [Parser].
+	##
 	## ```roc
 	## color : Parser(Utf8, [Red, Green, Blue])
 	## color = {
@@ -82,6 +82,8 @@ String :: {}.{
 		parser.parse_partial(input)
 	}
 
+	## Match one UTF-8 code unit when it satisfies the given predicate.
+	##
 	## ```roc
 	## is_digit : U8 -> Bool
 	## is_digit = |b| { b >= '0' and b <= '9' }
@@ -114,6 +116,8 @@ String :: {}.{
 		)
 	}
 
+	## Match one exact UTF-8 code unit.
+	##
 	## ```roc
 	## at_sign : Parser(Utf8, [AtSign])
 	## at_sign = Parser.const(AtSign).skip(codeunit('@'))
@@ -223,8 +227,7 @@ String :: {}.{
 		actual == bytes
 	}
 
-	# Matches any string
-	# as long as it is valid UTF8.
+	## Match all remaining input as a `Str`, failing if the bytes are not valid UTF-8.
 	any_string : Parser(Utf8, Str)
 	any_string = Parser.build_primitive_parser(
 		|field_utf8ing| {
@@ -238,6 +241,8 @@ String :: {}.{
 		},
 	)
 
+	## Parse one ASCII decimal digit into a `U64` from 0 through 9.
+	##
 	## ```roc
 	## expect digit->parse_str("0") == Ok(0)
 	## expect digit->parse_str("not a digit").is_err()
@@ -313,6 +318,8 @@ String :: {}.{
 		)
 	}
 
+	## Convert known-valid UTF-8 bytes to a `Str`.
+	## Crashes if the bytes are invalid UTF-8.
 	str_from_utf8 : Utf8 -> Str
 	str_from_utf8 = |raw_str| {
 		raw_str
@@ -322,6 +329,8 @@ String :: {}.{
 			}
 	}
 
+	## Convert one ASCII byte to a `Str`.
+	## Crashes if the byte is not valid as a single-byte UTF-8 scalar.
 	str_from_ascii : U8 -> Str
 	str_from_ascii = |ascii_num| {
 		match Str.from_utf8([ascii_num]) {

--- a/package/Xml.roc
+++ b/package/Xml.roc
@@ -1,48 +1,61 @@
-# # # XML Parser
-# # Original author: [Johannes Maas](https://github.com/j-maas)
-# #
-# # Following the specification from https://www.w3.org/TR/2008/REC-xml-20081126/
+# XML parser
+# Original author: [Johannes Maas](https://github.com/j-maas)
 import Parser
 import String
 
+## XML document tree and parser based on the XML 1.0 specification.
+##
+## The parser supports optional XML declarations, attributes, nested elements,
+## character data, CDATA sections, and self-closing elements.
 Xml :: {
 	xml_declaration : [Given(Xml.Declaration), Missing],
 	root : Xml.Node,
 }.{
+	## Compare two XML documents structurally.
 	is_eq : _
 
+	## An XML attribute name and decoded value.
 	Attribute : { name : Str, value : Str }
 
+	## Encoding declared by an XML declaration.
 	Encoding := [
 		Utf8Encoding,
 		OtherEncoding(Str),
 	].{
+		## Compare two XML encodings structurally.
 		is_eq : _
 	}
 
+	## Version and optional encoding from an XML declaration.
 	Declaration : {
 		version : Version,
 		encoding : [Given(Encoding), Missing],
 	}
 
+	## An XML 1.x version, storing the digit after `1.`.
 	Version :: {
 		after_dot : U8,
 	}.{
+		## Compare two XML versions.
 		is_eq : _
 
+		## Construct an XML 1.x version from the digit after `1.`.
 		new : U8 -> Version
 		new = |after_dot| {
 			{ after_dot }
 		}
 	}
 
+	## An XML element or text node.
 	Node := [
 		Element(Str, List({ name : Str, value : Str }), List(Node)),
 		Text(Str),
 	].{
+		## Compare two XML nodes structurally.
 		is_eq : _
 	}
 
+	## Parse one XML document, including an optional declaration and trailing whitespace.
 	xml_parser : Parser(String.Utf8, Xml)
 	xml_parser = 
 		Parser.const(

--- a/package/Xml.roc
+++ b/package/Xml.roc
@@ -9,12 +9,16 @@ Xml :: {
 	xml_declaration : [Given(Xml.Declaration), Missing],
 	root : Xml.Node,
 }.{
+	is_eq : _
+
 	Attribute : { name : Str, value : Str }
 
 	Encoding := [
 		Utf8Encoding,
 		OtherEncoding(Str),
-	]
+	].{
+		is_eq : _
+	}
 
 	Declaration : {
 		version : Version,
@@ -24,18 +28,20 @@ Xml :: {
 	Version :: {
 		after_dot : U8,
 	}.{
+		is_eq : _
+
 		new : U8 -> Version
 		new = |after_dot| {
 			{ after_dot }
 		}
-		is_eq : Version, Version -> Bool
-		is_eq = |v1, v2| v1.after_dot == v2.after_dot
 	}
 
 	Node := [
 		Element(Str, List({ name : Str, value : Str }), List(Node)),
 		Text(Str),
-	]
+	].{
+		is_eq : _
+	}
 
 	xml_parser : Parser(String.Utf8, Xml)
 	xml_parser = 
@@ -214,8 +220,13 @@ expect {
 
 # See https://www.w3.org/TR/2008/REC-xml-20081126/#NT-element
 p_element : Parser(String.Utf8, Xml.Node)
-p_element = 
-	Parser.const(
+p_element = Parser.build_primitive_parser(parse_element_partial)
+
+# Keep recursive parsing behind a function. Mutually recursive top-level parser
+# values currently trigger roc-lang/roc#10098.
+parse_element_partial : String.Utf8 -> Parser.ParseResult(String.Utf8, Xml.Node)
+parse_element_partial = |input| {
+	parser = Parser.const(
 		|name| {
 			|arguments| {
 				|contents| {
@@ -246,11 +257,14 @@ p_element =
 				)
 					.skip(String.string(">"))
 					.keep(
-						Parser.lazy(
-							|_| {
-								p_element_contents
-							},
-						),
+						Parser.one_of(
+							[
+								p_character_data,
+								Parser.build_primitive_parser(parse_element_partial),
+								p_cdata_section,
+							],
+						)
+							.many(),
 					)
 					.skip(p_end_tag),
 				String.string("/>").map(
@@ -260,6 +274,9 @@ p_element =
 				),
 			),
 		)
+
+	Parser.parse_partial(parser, input)
+}
 
 ## Empty elements can include whitespace before the self-closing marker.
 expect {
@@ -481,17 +498,6 @@ p_attribute_value = |quote| {
 		.flatten()
 }
 
-p_element_contents : Parser(String.Utf8, List(Xml.Node))
-p_element_contents = 
-	Parser.one_of(
-		[
-			p_character_data,
-			p_element,
-			p_cdata_section,
-		],
-	)
-		.many()
-
 # See https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ETag
 p_end_tag : Parser(String.Utf8, Str)
 p_end_tag = 
@@ -539,8 +545,11 @@ p_cdata_section =
 		.map(|s| Text(s))
 
 p_cdata_section_content : Parser(String.Utf8, Str)
-p_cdata_section_content = 
-	Parser.const(
+p_cdata_section_content = Parser.build_primitive_parser(parse_cdata_section_content_partial)
+
+parse_cdata_section_content_partial : String.Utf8 -> Parser.ParseResult(String.Utf8, Str)
+parse_cdata_section_content_partial = |input| {
+	parser = Parser.const(
 		|first| {
 			|rest| {
 				Str.concat(first, rest)
@@ -557,18 +566,17 @@ p_cdata_section_content =
 							""
 						},
 					),
-					Parser.lazy(
-						|_| {
-							p_cdata_section_content.map(
-								|rest| {
-									Str.concat("]", rest)
-								},
-							)
+					Parser.build_primitive_parser(parse_cdata_section_content_partial).map(
+						|rest| {
+							Str.concat("]", rest)
 						},
 					),
 				],
 			),
 		)
+
+	Parser.parse_partial(parser, input)
+}
 
 p_name : Parser(String.Utf8, Str)
 p_name = 

--- a/package/Yaml.roc
+++ b/package/Yaml.roc
@@ -19,6 +19,7 @@ Yaml := [
 	Mapping(List({ key : Str, value : Yaml })),
 ].{
 	Error : { line : U64, column : U64, message : Str }
+	is_eq : _
 
 	# # Parse one YAML configuration document from a string.
 	parse_str : Str -> Try(Yaml, [YamlError(Error)])
@@ -44,9 +45,6 @@ Yaml := [
 		}
 	}
 
-	is_eq : Yaml, Yaml -> Bool
-	is_eq = |left, right| yaml_is_eq(left, right)
-
 	to_inspect : Yaml -> Str
 	to_inspect = |value| inspect_yaml(value)
 }
@@ -55,17 +53,7 @@ Line : { content : String.Utf8, indent : U64, number : U64 }
 
 ParseResult : { val : Yaml, input : List(Line) }
 
-Quote := [NoQuote, SingleQuote, DoubleQuote].{
-	is_eq : Quote, Quote -> Bool
-	is_eq = |left, right| {
-		match { left, right } {
-			{ left: NoQuote, right: NoQuote } => Bool.True
-			{ left: SingleQuote, right: SingleQuote } => Bool.True
-			{ left: DoubleQuote, right: DoubleQuote } => Bool.True
-			_ => Bool.False
-		}
-	}
-}
+Quote : [NoQuote, SingleQuote, DoubleQuote]
 
 parse_node : List(Line), U64, U64 -> Try(ParseResult, [YamlError(Yaml.Error)])
 parse_node = |lines, indent, depth| {
@@ -689,20 +677,6 @@ lower_ascii = |bytes| {
 fail : U64, U64, Str -> Try(_, [YamlError(Yaml.Error)])
 fail = |line, column, message| Err(YamlError({ line, column, message }))
 
-yaml_is_eq : Yaml, Yaml -> Bool
-yaml_is_eq = |left, right| {
-	match { left, right } {
-		{ left: Null, right: Null } => Bool.True
-		{ left: Bool(a), right: Bool(b) } => a == b
-		{ left: Int(a), right: Int(b) } => a == b
-		{ left: Float(a), right: Float(b) } => a == b
-		{ left: String(a), right: String(b) } => a == b
-		{ left: Sequence(a), right: Sequence(b) } => a == b
-		{ left: Mapping(a), right: Mapping(b) } => a == b
-		_ => Bool.False
-	}
-}
-
 inspect_yaml : Yaml -> Str
 inspect_yaml = |value| {
 	match value {
@@ -716,6 +690,7 @@ inspect_yaml = |value| {
 	}
 }
 
+inspect_entry : { key : Str, value : Yaml } -> Str
 inspect_entry = |entry| "{ key: ${Str.inspect(entry.key)}, value: ${inspect_yaml(entry.value)} }"
 
 ## Empty documents parse as null.

--- a/package/Yaml.roc
+++ b/package/Yaml.roc
@@ -1,14 +1,14 @@
 import String
 
-# # # YAML configuration parser
-# #
-# # This module implements a deliberately small YAML 1.2-style subset aimed at
-# # configuration files and Markdown frontmatter. It supports a single block
-# # document, nested mappings and sequences, flow collections, comments, quoted
-# # strings, and common null, boolean, integer, and floating-point scalars.
-# #
-# # Anchors, aliases, tags, directives, block scalars, complex keys, and
-# # multi-document streams are rejected with a parse error.
+## A practical YAML configuration parser.
+##
+## This module implements a deliberately small YAML 1.2-style subset aimed at
+## configuration files and Markdown frontmatter. It supports a single block
+## document, nested mappings and sequences, flow collections, comments, quoted
+## strings, and common null, boolean, integer, and floating-point scalars.
+##
+## Anchors, aliases, tags, directives, block scalars, complex keys, and
+## multi-document streams are rejected with a parse error.
 Yaml := [
 	Null,
 	Bool(Bool),
@@ -18,10 +18,20 @@ Yaml := [
 	Sequence(List(Yaml)),
 	Mapping(List({ key : Str, value : Yaml })),
 ].{
+	## Location and explanation of invalid YAML input. Lines and columns are one-based.
 	Error : { line : U64, column : U64, message : Str }
+
+	## Compare two parsed YAML values structurally.
 	is_eq : _
 
-	# # Parse one YAML configuration document from a string.
+	## Parse one YAML configuration document from a string.
+	##
+	## Empty input produces `Null`. Invalid input returns `YamlError` with a
+	## one-based line and column. See the module description for the supported subset.
+	##
+	## ```roc
+	## expect Yaml.parse_str("draft: false") == Ok(Mapping([{ key: "draft", value: Bool(Bool.False) }]))
+	## ```
 	parse_str : Str -> Try(Yaml, [YamlError(Error)])
 	parse_str = |input| {
 		lines = prepare_lines(split_lines(input.to_utf8(), 1, [], []))?
@@ -45,6 +55,7 @@ Yaml := [
 		}
 	}
 
+	## Render a parsed YAML value in Roc source-like notation for inspection.
 	to_inspect : Yaml -> Str
 	to_inspect = |value| inspect_yaml(value)
 }

--- a/package/Yaml.roc
+++ b/package/Yaml.roc
@@ -1,0 +1,868 @@
+import String
+
+# # # YAML configuration parser
+# #
+# # This module implements a deliberately small YAML 1.2-style subset aimed at
+# # configuration files and Markdown frontmatter. It supports a single block
+# # document, nested mappings and sequences, flow collections, comments, quoted
+# # strings, and common null, boolean, integer, and floating-point scalars.
+# #
+# # Anchors, aliases, tags, directives, block scalars, complex keys, and
+# # multi-document streams are rejected with a parse error.
+Yaml := [
+	Null,
+	Bool(Bool),
+	Int(I64),
+	Float(F64),
+	String(Str),
+	Sequence(List(Yaml)),
+	Mapping(List({ key : Str, value : Yaml })),
+].{
+	Error : { line : U64, column : U64, message : Str }
+
+	# # Parse one YAML configuration document from a string.
+	parse_str : Str -> Try(Yaml, [YamlError(Error)])
+	parse_str = |input| {
+		lines = prepare_lines(split_lines(input.to_utf8(), 1, [], []))?
+
+		match lines {
+			[] => Ok(Null)
+
+			[first, ..] if first.indent != 0 =>
+				fail(first.number, 1, "the document root must not be indented")
+
+			[first, ..] => {
+				parsed = parse_node(lines, first.indent, 0)?
+
+				match parsed.input {
+					[] => Ok(parsed.val)
+
+					[leftover, ..] =>
+						fail(leftover.number, leftover.indent + 1, "unexpected content after the document root")
+					}
+			}
+		}
+	}
+
+	is_eq : Yaml, Yaml -> Bool
+	is_eq = |left, right| yaml_is_eq(left, right)
+
+	to_inspect : Yaml -> Str
+	to_inspect = |value| inspect_yaml(value)
+}
+
+Line : { content : String.Utf8, indent : U64, number : U64 }
+
+ParseResult : { val : Yaml, input : List(Line) }
+
+Quote := [NoQuote, SingleQuote, DoubleQuote].{
+	is_eq : Quote, Quote -> Bool
+	is_eq = |left, right| {
+		match { left, right } {
+			{ left: NoQuote, right: NoQuote } => Bool.True
+			{ left: SingleQuote, right: SingleQuote } => Bool.True
+			{ left: DoubleQuote, right: DoubleQuote } => Bool.True
+			_ => Bool.False
+		}
+	}
+}
+
+parse_node : List(Line), U64, U64 -> Try(ParseResult, [YamlError(Yaml.Error)])
+parse_node = |lines, indent, depth| {
+	if depth >= 100 {
+		match lines {
+			[line, ..] => fail(line.number, line.indent + 1, "YAML nesting exceeds the supported limit of 100 levels")
+			[] => fail(1, 1, "YAML nesting exceeds the supported limit of 100 levels")
+		}
+	} else {
+		match lines {
+			[] => fail(1, 1, "expected a YAML value")
+
+			[first, ..] if first.indent != indent =>
+				fail(first.number, first.indent + 1, "unexpected indentation")
+
+			[first, ..] if is_sequence_line(first.content) =>
+				parse_sequence(lines, indent, depth)
+
+			[first, ..] => {
+				match split_mapping_entry(first.content) {
+					Ok(_) => parse_mapping(lines, indent, depth)
+					Err(_) => {
+						value = parse_inline_value(first.content, first.number, first.indent + 1)?
+						Ok({ val: value, input: lines.drop_first(1) })
+					}
+				}
+			}
+		}
+	}
+}
+
+parse_mapping : List(Line), U64, U64 -> Try(ParseResult, [YamlError(Yaml.Error)])
+parse_mapping = |lines, indent, depth| {
+	parse_mapping_help(lines, indent, depth, [])
+}
+
+parse_mapping_help : List(Line), U64, U64, List({ key : Str, value : Yaml }) -> Try(ParseResult, [YamlError(Yaml.Error)])
+parse_mapping_help = |lines, indent, depth, entries| {
+	match lines {
+		[] => Ok({ val: Mapping(entries), input: [] })
+
+		[line, ..] if line.indent < indent =>
+			Ok({ val: Mapping(entries), input: lines })
+
+		[line, ..] if line.indent > indent =>
+			fail(line.number, line.indent + 1, "unexpected indentation after a mapping value")
+
+		[line, ..] if is_sequence_line(line.content) =>
+			Ok({ val: Mapping(entries), input: lines })
+
+		[line, .. as rest] => {
+			match split_mapping_entry(line.content) {
+				Err(_) => Ok({ val: Mapping(entries), input: lines })
+
+				Ok(parts) => {
+					key = parse_key(parts.key, line.number, line.indent + 1)?
+
+					if mapping_has_key(entries, key) {
+						fail(line.number, line.indent + 1, "duplicate mapping key `${key}`")
+					} else if parts.value.is_empty() {
+						match rest {
+							[next, ..] if next.indent > indent => {
+								child = parse_node(rest, next.indent, depth + 1)?
+								parse_mapping_help(child.input, indent, depth, entries.append({ key, value: child.val }))
+							}
+
+							_ =>
+								parse_mapping_help(rest, indent, depth, entries.append({ key, value: Null }))
+							}
+					} else {
+						value = parse_inline_value(parts.value, line.number, line.indent + parts.value_column)?
+						parse_mapping_help(rest, indent, depth, entries.append({ key, value }))
+					}
+				}
+			}
+		}
+	}
+}
+
+parse_sequence : List(Line), U64, U64 -> Try(ParseResult, [YamlError(Yaml.Error)])
+parse_sequence = |lines, indent, depth| {
+	parse_sequence_help(lines, indent, depth, [])
+}
+
+parse_sequence_help : List(Line), U64, U64, List(Yaml) -> Try(ParseResult, [YamlError(Yaml.Error)])
+parse_sequence_help = |lines, indent, depth, values| {
+	match lines {
+		[] => Ok({ val: Sequence(values), input: [] })
+
+		[line, ..] if line.indent < indent =>
+			Ok({ val: Sequence(values), input: lines })
+
+		[line, ..] if line.indent > indent =>
+			fail(line.number, line.indent + 1, "unexpected indentation after a sequence value")
+
+		[line, ..] if !is_sequence_line(line.content) =>
+			Ok({ val: Sequence(values), input: lines })
+
+		[line, .. as rest] => {
+			payload = sequence_payload(line.content)
+
+			if payload.is_empty() {
+				match rest {
+					[next, ..] if next.indent > indent => {
+						child = parse_node(rest, next.indent, depth + 1)?
+						parse_sequence_help(child.input, indent, depth, values.append(child.val))
+					}
+
+					_ =>
+						parse_sequence_help(rest, indent, depth, values.append(Null))
+					}
+			} else {
+				match split_mapping_entry(payload) {
+					Ok(_) => {
+						virtual = { content: payload, indent: indent + 2, number: line.number }
+						child = parse_node(List.prepend(rest, virtual), indent + 2, depth + 1)?
+						parse_sequence_help(child.input, indent, depth, values.append(child.val))
+					}
+
+					Err(_) => {
+						value = parse_inline_value(payload, line.number, line.indent + 3)?
+						parse_sequence_help(rest, indent, depth, values.append(value))
+					}
+				}
+			}
+		}
+	}
+}
+
+parse_inline_value : String.Utf8, U64, U64 -> Try(Yaml, [YamlError(Yaml.Error)])
+parse_inline_value = |raw, line, column| {
+	bytes = trim_spaces(raw)
+
+	match bytes {
+		[] => Ok(Null)
+
+		['[', ..] => parse_flow_sequence(bytes, line, column)
+
+		['{', ..] => parse_flow_mapping(bytes, line, column)
+
+		['|', ..] | ['>', ..] =>
+			fail(line, column, "block scalars are not supported by this YAML subset")
+
+		['&', ..] | ['*', ..] | ['!', ..] =>
+			fail(line, column, "anchors, aliases, and tags are not supported by this YAML subset")
+
+		['%', ..] =>
+			fail(line, column, "YAML directives are not supported by this YAML subset")
+
+		['?', ..] =>
+			fail(line, column, "complex mapping keys are not supported by this YAML subset")
+
+		['"', ..] =>
+			parse_double_quoted(bytes, line, column).map_ok(|text| String(text))
+
+		['\'', ..] =>
+			parse_single_quoted(bytes, line, column).map_ok(|text| String(text))
+
+		_ => parse_plain_scalar(bytes, line, column)
+	}
+}
+
+parse_plain_scalar : String.Utf8, U64, U64 -> Try(Yaml, [YamlError(Yaml.Error)])
+parse_plain_scalar = |bytes, line, column| {
+	lower = lower_ascii(bytes)
+	text = String.str_from_utf8(bytes)
+
+	if lower == "null".to_utf8() or bytes == "~".to_utf8() {
+		Ok(Null)
+	} else if lower == "true".to_utf8() {
+		Ok(Bool(Bool.True))
+	} else if lower == "false".to_utf8() {
+		Ok(Bool(Bool.False))
+	} else if is_decimal_integer(bytes) {
+		match I64.from_str(text) {
+			Ok(value) => Ok(Int(value))
+			Err(_) => fail(line, column, "integer `${text}` is outside the supported I64 range")
+		}
+	} else if looks_like_float(bytes) {
+		match F64.from_str(text) {
+			Ok(value) => Ok(Float(value))
+			Err(_) => fail(line, column, "invalid floating-point value `${text}`")
+		}
+	} else {
+		Ok(String(text))
+	}
+}
+
+parse_flow_sequence : String.Utf8, U64, U64 -> Try(Yaml, [YamlError(Yaml.Error)])
+parse_flow_sequence = |bytes, line, column| {
+	inner = unwrap_flow(bytes, '[', ']', line, column)?
+
+	if trim_spaces(inner).is_empty() {
+		Ok(Sequence([]))
+	} else {
+		parts = split_flow_items(inner, line, column)?
+		values = parse_flow_values(parts, line, column, [])?
+		Ok(Sequence(values))
+	}
+}
+
+parse_flow_values : List(String.Utf8), U64, U64, List(Yaml) -> Try(List(Yaml), [YamlError(Yaml.Error)])
+parse_flow_values = |parts, line, column, values| {
+	match parts {
+		[] => Ok(values)
+		[part, .. as rest] => {
+			value = parse_inline_value(part, line, column)?
+			parse_flow_values(rest, line, column, values.append(value))
+		}
+	}
+}
+
+parse_flow_mapping : String.Utf8, U64, U64 -> Try(Yaml, [YamlError(Yaml.Error)])
+parse_flow_mapping = |bytes, line, column| {
+	inner = unwrap_flow(bytes, '{', '}', line, column)?
+
+	if trim_spaces(inner).is_empty() {
+		Ok(Mapping([]))
+	} else {
+		parts = split_flow_items(inner, line, column)?
+		entries = parse_flow_entries(parts, line, column, [])?
+		Ok(Mapping(entries))
+	}
+}
+
+parse_flow_entries : List(String.Utf8), U64, U64, List({ key : Str, value : Yaml }) -> Try(List({ key : Str, value : Yaml }), [YamlError(Yaml.Error)])
+parse_flow_entries = |parts, line, column, entries| {
+	match parts {
+		[] => Ok(entries)
+
+		[part, .. as rest] => {
+			match split_mapping_entry(trim_spaces(part)) {
+				Err(_) => fail(line, column, "expected a key and value in flow mapping")
+
+				Ok(split) => {
+					key = parse_key(split.key, line, column)?
+
+					if mapping_has_key(entries, key) {
+						fail(line, column, "duplicate mapping key `${key}`")
+					} else {
+						value = parse_inline_value(split.value, line, column)?
+						parse_flow_entries(rest, line, column, entries.append({ key, value }))
+					}
+				}
+			}
+		}
+	}
+}
+
+parse_key : String.Utf8, U64, U64 -> Try(Str, [YamlError(Yaml.Error)])
+parse_key = |raw, line, column| {
+	bytes = trim_spaces(raw)
+
+	match bytes {
+		[] => fail(line, column, "mapping keys must not be empty")
+		['"', ..] => parse_double_quoted(bytes, line, column)
+		['\'', ..] => parse_single_quoted(bytes, line, column)
+		['[', ..] | ['{', ..] | ['?', ..] => fail(line, column, "complex mapping keys are not supported by this YAML subset")
+		_ => Ok(String.str_from_utf8(bytes))
+	}
+}
+
+parse_single_quoted : String.Utf8, U64, U64 -> Try(Str, [YamlError(Yaml.Error)])
+parse_single_quoted = |bytes, line, column| {
+	if bytes.len() < 2 or bytes.get(bytes.len() - 1) != Ok('\'') {
+		fail(line, column, "unterminated single-quoted string")
+	} else {
+		inner = bytes.sublist({ start: 1, len: bytes.len() - 2 })
+		unescape_single(inner, [], line, column).map_ok(String.str_from_utf8)
+	}
+}
+
+unescape_single : String.Utf8, String.Utf8, U64, U64 -> Try(String.Utf8, [YamlError(Yaml.Error)])
+unescape_single = |bytes, out, line, column| {
+	match bytes {
+		[] => Ok(out)
+		['\'', '\'', .. as rest] => unescape_single(rest, out.append('\''), line, column)
+		['\'', ..] => fail(line, column, "a single quote inside a quoted string must be doubled")
+		[first, .. as rest] => unescape_single(rest, out.append(first), line, column)
+	}
+}
+
+parse_double_quoted : String.Utf8, U64, U64 -> Try(Str, [YamlError(Yaml.Error)])
+parse_double_quoted = |bytes, line, column| {
+	if bytes.len() < 2 or bytes.get(bytes.len() - 1) != Ok('"') {
+		fail(line, column, "unterminated double-quoted string")
+	} else {
+		inner = bytes.sublist({ start: 1, len: bytes.len() - 2 })
+		unescape_double(inner, [], line, column).map_ok(String.str_from_utf8)
+	}
+}
+
+unescape_double : String.Utf8, String.Utf8, U64, U64 -> Try(String.Utf8, [YamlError(Yaml.Error)])
+unescape_double = |bytes, out, line, column| {
+	match bytes {
+		[] => Ok(out)
+		['\\', '"', .. as rest] => unescape_double(rest, out.append('"'), line, column)
+		['\\', '\\', .. as rest] => unescape_double(rest, out.append('\\'), line, column)
+		['\\', 'n', .. as rest] => unescape_double(rest, out.append('\n'), line, column)
+		['\\', 'r', .. as rest] => unescape_double(rest, out.append('\r'), line, column)
+		['\\', 't', .. as rest] => unescape_double(rest, out.append('\t'), line, column)
+		['\\', escaped, ..] => fail(line, column, "unsupported escape sequence `\\${String.str_from_utf8([escaped])}`")
+		['\\'] => fail(line, column, "unterminated escape sequence")
+		[first, .. as rest] => unescape_double(rest, out.append(first), line, column)
+	}
+}
+
+prepare_lines : List(Line) -> Try(List(Line), [YamlError(Yaml.Error)])
+prepare_lines = |raw_lines| {
+	clean = clean_lines(raw_lines, [])?
+
+	without_start =
+		match clean {
+			[first, .. as rest] if first.indent == 0 and first.content == "---".to_utf8() => rest
+			_ => clean
+		}
+
+	remove_document_end(without_start, [])
+}
+
+clean_lines : List(Line), List(Line) -> Try(List(Line), [YamlError(Yaml.Error)])
+clean_lines = |lines, out| {
+	match lines {
+		[] => Ok(out)
+
+		[line, .. as rest] => {
+			indent = count_indent(line.content, 0, line.number)?
+			content = trim_end_spaces(strip_comment(line.content.drop_first(indent), NoQuote, Bool.False, Bool.True, []))
+
+			if content.is_empty() {
+				clean_lines(rest, out)
+			} else {
+				clean_lines(rest, out.append({ content, indent, number: line.number }))
+			}
+		}
+	}
+}
+
+remove_document_end : List(Line), List(Line) -> Try(List(Line), [YamlError(Yaml.Error)])
+remove_document_end = |lines, out| {
+	match lines {
+		[] => Ok(out)
+
+		[line, .. as rest] if line.indent == 0 and line.content == "...".to_utf8() => {
+			match rest {
+				[] => Ok(out)
+				[next, ..] => fail(next.number, next.indent + 1, "multiple YAML documents are not supported")
+			}
+		}
+
+		[line, ..] if line.indent == 0 and line.content == "---".to_utf8() =>
+			fail(line.number, 1, "multiple YAML documents are not supported")
+
+		[line, .. as rest] => remove_document_end(rest, out.append(line))
+	}
+}
+
+split_lines : String.Utf8, U64, String.Utf8, List(Line) -> List(Line)
+split_lines = |input, number, current, lines| {
+	match input {
+		[] => lines.append({ content: current, indent: 0, number })
+		['\r', '\n', .. as rest] => split_lines(rest, number + 1, [], lines.append({ content: current, indent: 0, number }))
+		['\n', .. as rest] => split_lines(rest, number + 1, [], lines.append({ content: current, indent: 0, number }))
+		[first, .. as rest] => split_lines(rest, number, current.append(first), lines)
+	}
+}
+
+count_indent : String.Utf8, U64, U64 -> Try(U64, [YamlError(Yaml.Error)])
+count_indent = |bytes, count, line| {
+	match bytes {
+		[' ', .. as rest] => count_indent(rest, count + 1, line)
+		['\t', ..] => fail(line, count + 1, "tabs may not be used for YAML indentation")
+		_ => Ok(count)
+	}
+}
+
+strip_comment : String.Utf8, Quote, Bool, Bool, String.Utf8 -> String.Utf8
+strip_comment = |bytes, quote, escaped, separated, out| {
+	match bytes {
+		[] => out
+
+		[first, ..] if first == '#' and quote == NoQuote and separated => out
+
+		['\\', .. as rest] if quote == DoubleQuote and !escaped =>
+			strip_comment(rest, quote, Bool.True, Bool.False, out.append('\\'))
+
+		['"', .. as rest] if quote == NoQuote =>
+			strip_comment(rest, DoubleQuote, Bool.False, Bool.False, out.append('"'))
+
+		['"', .. as rest] if quote == DoubleQuote and !escaped =>
+			strip_comment(rest, NoQuote, Bool.False, Bool.False, out.append('"'))
+
+		['\'', .. as rest] if quote == NoQuote =>
+			strip_comment(rest, SingleQuote, Bool.False, Bool.False, out.append('\''))
+
+		['\'', .. as rest] if quote == SingleQuote =>
+			strip_comment(rest, NoQuote, Bool.False, Bool.False, out.append('\''))
+
+		[first, .. as rest] =>
+			strip_comment(rest, quote, Bool.False, first == ' ' or first == '\t', out.append(first))
+		}
+}
+
+split_mapping_entry : String.Utf8 -> Try({ key : String.Utf8, value : String.Utf8, value_column : U64 }, [NotFound])
+split_mapping_entry = |bytes| {
+	find_mapping_colon(bytes, bytes, NoQuote, Bool.False, 0, 0, 0)
+}
+
+find_mapping_colon : String.Utf8, String.Utf8, Quote, Bool, U64, U64, U64 -> Try({ key : String.Utf8, value : String.Utf8, value_column : U64 }, [NotFound])
+find_mapping_colon = |all, bytes, quote, escaped, square_depth, curly_depth, index| {
+	match bytes {
+		[] => Err(NotFound)
+
+		[':', .. as rest] if quote == NoQuote and square_depth == 0 and curly_depth == 0 and (rest.is_empty() or starts_with_space(rest)) =>
+			Ok({ key: all.sublist({ start: 0, len: index }), value: trim_start_spaces(rest), value_column: index + 2 })
+
+		['\\', .. as rest] if quote == DoubleQuote and !escaped =>
+			find_mapping_colon(all, rest, quote, Bool.True, square_depth, curly_depth, index + 1)
+
+		['"', .. as rest] if quote == NoQuote =>
+			find_mapping_colon(all, rest, DoubleQuote, Bool.False, square_depth, curly_depth, index + 1)
+
+		['"', .. as rest] if quote == DoubleQuote and !escaped =>
+			find_mapping_colon(all, rest, NoQuote, Bool.False, square_depth, curly_depth, index + 1)
+
+		['\'', .. as rest] if quote == NoQuote =>
+			find_mapping_colon(all, rest, SingleQuote, Bool.False, square_depth, curly_depth, index + 1)
+
+		['\'', .. as rest] if quote == SingleQuote =>
+			find_mapping_colon(all, rest, NoQuote, Bool.False, square_depth, curly_depth, index + 1)
+
+		['[', .. as rest] if quote == NoQuote => find_mapping_colon(all, rest, quote, Bool.False, square_depth + 1, curly_depth, index + 1)
+		[']', .. as rest] if quote == NoQuote and square_depth > 0 => find_mapping_colon(all, rest, quote, Bool.False, square_depth - 1, curly_depth, index + 1)
+		['{', .. as rest] if quote == NoQuote => find_mapping_colon(all, rest, quote, Bool.False, square_depth, curly_depth + 1, index + 1)
+		['}', .. as rest] if quote == NoQuote and curly_depth > 0 => find_mapping_colon(all, rest, quote, Bool.False, square_depth, curly_depth - 1, index + 1)
+
+		[_, .. as rest] => find_mapping_colon(all, rest, quote, Bool.False, square_depth, curly_depth, index + 1)
+	}
+}
+
+split_flow_items : String.Utf8, U64, U64 -> Try(List(String.Utf8), [YamlError(Yaml.Error)])
+split_flow_items = |bytes, line, column| {
+	split_flow_items_help(bytes, [], [], NoQuote, Bool.False, 0, 0, line, column)
+}
+
+split_flow_items_help : String.Utf8, String.Utf8, List(String.Utf8), Quote, Bool, U64, U64, U64, U64 -> Try(List(String.Utf8), [YamlError(Yaml.Error)])
+split_flow_items_help = |bytes, current, items, quote, escaped, square_depth, curly_depth, line, column| {
+	match bytes {
+		[] if quote != NoQuote => fail(line, column, "unterminated quoted string in flow collection")
+		[] if square_depth != 0 or curly_depth != 0 => fail(line, column, "unterminated nested flow collection")
+		[] if trim_spaces(current).is_empty() => fail(line, column, "flow collections may not contain an empty item")
+		[] => Ok(items.append(trim_spaces(current)))
+
+		[',', .. as rest] if quote == NoQuote and square_depth == 0 and curly_depth == 0 => {
+			if trim_spaces(current).is_empty() {
+				fail(line, column, "flow collections may not contain an empty item")
+			} else {
+				split_flow_items_help(rest, [], items.append(trim_spaces(current)), quote, Bool.False, square_depth, curly_depth, line, column)
+			}
+		}
+
+		['\\', .. as rest] if quote == DoubleQuote and !escaped => split_flow_items_help(rest, current.append('\\'), items, quote, Bool.True, square_depth, curly_depth, line, column)
+		['"', .. as rest] if quote == NoQuote => split_flow_items_help(rest, current.append('"'), items, DoubleQuote, Bool.False, square_depth, curly_depth, line, column)
+		['"', .. as rest] if quote == DoubleQuote and !escaped => split_flow_items_help(rest, current.append('"'), items, NoQuote, Bool.False, square_depth, curly_depth, line, column)
+		['\'', .. as rest] if quote == NoQuote => split_flow_items_help(rest, current.append('\''), items, SingleQuote, Bool.False, square_depth, curly_depth, line, column)
+		['\'', .. as rest] if quote == SingleQuote => split_flow_items_help(rest, current.append('\''), items, NoQuote, Bool.False, square_depth, curly_depth, line, column)
+		['[', .. as rest] if quote == NoQuote => split_flow_items_help(rest, current.append('['), items, quote, Bool.False, square_depth + 1, curly_depth, line, column)
+		[']', ..] if quote == NoQuote and square_depth == 0 => fail(line, column, "unexpected closing bracket in flow collection")
+		[']', .. as rest] if quote == NoQuote => split_flow_items_help(rest, current.append(']'), items, quote, Bool.False, square_depth - 1, curly_depth, line, column)
+		['{', .. as rest] if quote == NoQuote => split_flow_items_help(rest, current.append('{'), items, quote, Bool.False, square_depth, curly_depth + 1, line, column)
+		['}', ..] if quote == NoQuote and curly_depth == 0 => fail(line, column, "unexpected closing brace in flow collection")
+		['}', .. as rest] if quote == NoQuote => split_flow_items_help(rest, current.append('}'), items, quote, Bool.False, square_depth, curly_depth - 1, line, column)
+		[first, .. as rest] => split_flow_items_help(rest, current.append(first), items, quote, Bool.False, square_depth, curly_depth, line, column)
+	}
+}
+
+unwrap_flow : String.Utf8, U8, U8, U64, U64 -> Try(String.Utf8, [YamlError(Yaml.Error)])
+unwrap_flow = |bytes, open, close, line, column| {
+	if bytes.len() < 2 or bytes.get(0) != Ok(open) or bytes.get(bytes.len() - 1) != Ok(close) {
+		fail(line, column, "unterminated flow collection")
+	} else {
+		Ok(bytes.sublist({ start: 1, len: bytes.len() - 2 }))
+	}
+}
+
+is_sequence_line : String.Utf8 -> Bool
+is_sequence_line = |bytes| {
+	match bytes {
+		['-'] => Bool.True
+		['-', ' ', ..] => Bool.True
+		_ => Bool.False
+	}
+}
+
+sequence_payload : String.Utf8 -> String.Utf8
+sequence_payload = |bytes| {
+	match bytes {
+		['-'] => []
+		['-', ' ', .. as rest] => trim_spaces(rest)
+		_ => bytes
+	}
+}
+
+mapping_has_key : List({ key : Str, value : Yaml }), Str -> Bool
+mapping_has_key = |entries, key| {
+	match entries {
+		[] => Bool.False
+		[first, ..] if first.key == key => Bool.True
+		[_, .. as rest] => mapping_has_key(rest, key)
+	}
+}
+
+is_decimal_integer : String.Utf8 -> Bool
+is_decimal_integer = |bytes| {
+	match bytes {
+		['+', .. as rest] | ['-', .. as rest] => !rest.is_empty() and all_digits(rest)
+		_ => !bytes.is_empty() and all_digits(bytes)
+	}
+}
+
+all_digits : String.Utf8 -> Bool
+all_digits = |bytes| {
+	match bytes {
+		[] => Bool.True
+		[first, .. as rest] => first >= '0' and first <= '9' and all_digits(rest)
+	}
+}
+
+looks_like_float : String.Utf8 -> Bool
+looks_like_float = |bytes| {
+	has_float_marker = contains_byte(bytes, '.') or contains_byte(bytes, 'e') or contains_byte(bytes, 'E')
+	has_digit = bytes_contains_digit(bytes)
+	valid_characters = all_float_characters(bytes)
+
+	match bytes {
+		['+', first, ..] | ['-', first, ..] => has_float_marker and has_digit and valid_characters and (is_digit(first) or first == '.')
+		[first, ..] => has_float_marker and has_digit and valid_characters and (is_digit(first) or first == '.')
+		[] => Bool.False
+	}
+}
+
+is_digit : U8 -> Bool
+is_digit = |byte| byte >= '0' and byte <= '9'
+
+bytes_contains_digit : String.Utf8 -> Bool
+bytes_contains_digit = |bytes| {
+	match bytes {
+		[] => Bool.False
+		[first, ..] if is_digit(first) => Bool.True
+		[_, .. as rest] => bytes_contains_digit(rest)
+	}
+}
+
+all_float_characters : String.Utf8 -> Bool
+all_float_characters = |bytes| {
+	match bytes {
+		[] => Bool.True
+		[first, .. as rest] =>
+			(is_digit(first) or first == '.' or first == 'e' or first == 'E' or first == '+' or first == '-') and all_float_characters(rest)
+		}
+}
+
+contains_byte : String.Utf8, U8 -> Bool
+contains_byte = |bytes, expected| {
+	match bytes {
+		[] => Bool.False
+		[first, ..] if first == expected => Bool.True
+		[_, .. as rest] => contains_byte(rest, expected)
+	}
+}
+
+starts_with_space : String.Utf8 -> Bool
+starts_with_space = |bytes| {
+	match bytes {
+		[' ', ..] | ['\t', ..] => Bool.True
+		_ => Bool.False
+	}
+}
+
+trim_spaces : String.Utf8 -> String.Utf8
+trim_spaces = |bytes| trim_end_spaces(trim_start_spaces(bytes))
+
+trim_start_spaces : String.Utf8 -> String.Utf8
+trim_start_spaces = |bytes| {
+	match bytes {
+		[' ', .. as rest] | ['\t', .. as rest] => trim_start_spaces(rest)
+		_ => bytes
+	}
+}
+
+trim_end_spaces : String.Utf8 -> String.Utf8
+trim_end_spaces = |bytes| trim_end_spaces_help(bytes, [], [])
+
+trim_end_spaces_help : String.Utf8, String.Utf8, String.Utf8 -> String.Utf8
+trim_end_spaces_help = |bytes, out, pending| {
+	match bytes {
+		[] => out
+		[' ', .. as rest] => trim_end_spaces_help(rest, out, pending.append(' '))
+		['\t', .. as rest] => trim_end_spaces_help(rest, out, pending.append('\t'))
+		[first, .. as rest] => trim_end_spaces_help(rest, append_bytes(out, pending).append(first), [])
+	}
+}
+
+append_bytes : String.Utf8, String.Utf8 -> String.Utf8
+append_bytes = |left, right| {
+	match right {
+		[] => left
+		[first, .. as rest] => append_bytes(left.append(first), rest)
+	}
+}
+
+lower_ascii : String.Utf8 -> String.Utf8
+lower_ascii = |bytes| {
+	match bytes {
+		[] => []
+		[first, .. as rest] if first >= 'A' and first <= 'Z' => List.prepend(lower_ascii(rest), first + 32)
+		[first, .. as rest] => List.prepend(lower_ascii(rest), first)
+	}
+}
+
+fail : U64, U64, Str -> Try(_, [YamlError(Yaml.Error)])
+fail = |line, column, message| Err(YamlError({ line, column, message }))
+
+yaml_is_eq : Yaml, Yaml -> Bool
+yaml_is_eq = |left, right| {
+	match { left, right } {
+		{ left: Null, right: Null } => Bool.True
+		{ left: Bool(a), right: Bool(b) } => a == b
+		{ left: Int(a), right: Int(b) } => a == b
+		{ left: Float(a), right: Float(b) } => a == b
+		{ left: String(a), right: String(b) } => a == b
+		{ left: Sequence(a), right: Sequence(b) } => a == b
+		{ left: Mapping(a), right: Mapping(b) } => a == b
+		_ => Bool.False
+	}
+}
+
+inspect_yaml : Yaml -> Str
+inspect_yaml = |value| {
+	match value {
+		Null => "Null"
+		Bool(boolean) => "Bool(${Str.inspect(boolean)})"
+		Int(integer) => "Int(${integer.to_str()})"
+		Float(float) => "Float(${float.to_str()})"
+		String(text) => "String(${Str.inspect(text)})"
+		Sequence(values) => "Sequence([${values.map(inspect_yaml)->Str.join_with(", ")}])"
+		Mapping(entries) => "Mapping([${entries.map(inspect_entry)->Str.join_with(", ")}])"
+	}
+}
+
+inspect_entry = |entry| "{ key: ${Str.inspect(entry.key)}, value: ${inspect_yaml(entry.value)} }"
+
+## Empty documents parse as null.
+expect Yaml.parse_str("") == Ok(Null)
+
+## Common frontmatter scalars resolve to useful values.
+expect {
+	actual =
+		Yaml.parse_str(
+			\\title: A small article
+			\\draft: false
+			\\count: 3
+			\\rating: 4.5
+			\\description: null
+			,
+		)?
+
+	actual
+		== Mapping([
+			{ key: "title", value: String("A small article") },
+			{ key: "draft", value: Bool(Bool.False) },
+			{ key: "count", value: Int(3) },
+			{ key: "rating", value: Float(4.5) },
+			{ key: "description", value: Null },
+		])
+}
+
+## Nested mappings and sequences parse by indentation.
+expect {
+	actual =
+		Yaml.parse_str(
+			\\site:
+			\\  title: Roc
+			\\  tags:
+			\\    - parser
+			\\    - yaml
+			,
+		)?
+
+	actual
+		== Mapping([
+			{
+				key: "site",
+				value: Mapping([
+					{ key: "title", value: String("Roc") },
+					{ key: "tags", value: Sequence([String("parser"), String("yaml")]) },
+				]),
+			},
+		])
+}
+
+## Sequence items may be compact mappings.
+expect {
+	actual =
+		Yaml.parse_str(
+			\\people:
+			\\  - name: Ada
+			\\    active: true
+			\\  - name: Grace
+			,
+		)?
+
+	actual
+		== Mapping([
+			{
+				key: "people",
+				value: Sequence([
+					Mapping([{ key: "name", value: String("Ada") }, { key: "active", value: Bool(Bool.True) }]),
+					Mapping([{ key: "name", value: String("Grace") }]),
+				]),
+			},
+		])
+}
+
+## Flow collections support concise config values.
+expect {
+	actual = Yaml.parse_str("ports: [80, 443]\nlabels: { tier: web, public: true }")?
+
+	actual
+		== Mapping([
+			{ key: "ports", value: Sequence([Int(80), Int(443)]) },
+			{ key: "labels", value: Mapping([{ key: "tier", value: String("web") }, { key: "public", value: Bool(Bool.True) }]) },
+		])
+}
+
+## Quotes preserve scalar strings and comment markers.
+expect {
+	actual = Yaml.parse_str("enabled: \"true\"\nmessage: 'it''s # text' # comment")?
+	actual == Mapping([{ key: "enabled", value: String("true") }, { key: "message", value: String("it's # text") }])
+}
+
+## Optional document markers work for Markdown frontmatter bodies.
+expect {
+	actual = Yaml.parse_str("---\ntitle: Post\n...")?
+	actual == Mapping([{ key: "title", value: String("Post") }])
+}
+
+## Duplicate mapping keys fail.
+expect Yaml.parse_str("name: first\nname: second").is_err()
+
+## Tabs used for indentation fail.
+expect Yaml.parse_str("root:\n\tchild: value").is_err()
+
+## Advanced YAML features fail explicitly.
+expect Yaml.parse_str("value: &anchor text").is_err()
+
+## Multiple documents are outside the supported subset.
+expect Yaml.parse_str("one: 1\n---\ntwo: 2").is_err()
+
+## Plain strings containing dots or the letter e are not mistaken for floats.
+expect {
+	actual = Yaml.parse_str("file: .git\nname: release")?
+	actual == Mapping([{ key: "file", value: String(".git") }, { key: "name", value: String("release") }])
+}
+
+## Syntax errors report their source location.
+expect {
+	match Yaml.parse_str("root:\n\tchild: value") {
+		Err(YamlError(problem)) => problem.line == 2 and problem.column == 1
+		Ok(_) => Bool.False
+	}
+}
+
+## Root sequences and empty entries are supported.
+expect {
+	actual = Yaml.parse_str("- first\n-\n- third")?
+	actual == Sequence([String("first"), Null, String("third")])
+}
+
+## CRLF input and comment-only lines are ignored correctly.
+expect {
+	actual = Yaml.parse_str("# config\r\nname: roc-parser\r\n")?
+	actual == Mapping([{ key: "name", value: String("roc-parser") }])
+}
+
+## Nested flow collections keep quoted commas inside strings.
+expect {
+	actual = Yaml.parse_str("value: [{ name: 'one,two' }, [1, 2]]")?
+	actual == Mapping([{ key: "value", value: Sequence([Mapping([{ key: "name", value: String("one,two") }]), Sequence([Int(1), Int(2)])]) }])
+}
+
+## Double-quoted strings support common escapes.
+expect {
+	actual = Yaml.parse_str("message: \"first\\nsecond\"")?
+	actual == Mapping([{ key: "message", value: String("first\nsecond") }])
+}
+
+## Block scalars and malformed flow collections fail rather than degrading to strings.
+expect Yaml.parse_str("description: |\n  multiline").is_err()
+expect Yaml.parse_str("values: [one, two").is_err()

--- a/package/main.roc
+++ b/package/main.roc
@@ -6,5 +6,6 @@ package
 		HTTP,
 		Markdown,
 		Xml,
+		Yaml,
 	]
 	{}


### PR DESCRIPTION
## Summary

- add a `Yaml` module for configuration files and Markdown frontmatter
- parse one document with block mappings, block sequences, flow collections, comments, quoted strings, and common scalar values
- report line and column information for malformed input and reject unsupported advanced YAML features explicitly
- export the module, document its supported subset, and run its tests in CI
- add rendered module documentation and doc comments for every public package entry
- replace handwritten equality implementations with compiler-derived `is_eq` methods and add missing top-level annotations
- work around [roc-lang/roc#10098](https://github.com/roc-lang/roc/issues/10098) in the recursive XML parser without changing its public API
- make standalone examples skip `argv[0]`, so their fallback input works and release-bundle binaries run reliably

## Deliberate YAML scope

This is a practical YAML subset rather than a fully compliant YAML processor. Anchors, aliases, tags, directives, block scalars, complex keys, and multi-document streams are not supported.

## Testing

- `roc check --no-cache package/main.roc` — no errors
- Parser, String, CSV, Markdown, XML, and YAML suites — all 198 tests pass
- `roc docs package/main.roc` — docs generated successfully; all 7 modules and 108 public entries are documented
- release package bundle — created successfully
- bundled examples — all check, run, build, and execute successfully
- `git diff --check` — clean

`package/HTTP.roc` remains included in the successful package check. Its test execution is still skipped by CI because of the existing, documented nightly compiler segfault.
