### PR TITLE
Reject overflowing decimal inputs

### DIFF
--- a/package/HTTP.roc
+++ b/package/HTTP.roc
@@ -191,6 +191,9 @@ expect {
 	actual == expected
 }
 
+## Oversized HTTP version numbers return a parse error instead of crashing.
+expect String.parse_str(http_version, "HTTP/1.044444444444444444444").is_err()
+
 string_without_colon : Parser(String.Utf8, Str)
 string_without_colon =
 	String.codeunit_satisfies(

--- a/package/String.roc
+++ b/package/String.roc
@@ -275,13 +275,22 @@ String :: {}.{
 			.map(
 				|ds| {
 					ds.fold(
-						0,
-						|sum, d| {
-							sum * 10 + d
+						Ok(0),
+						|result, d| {
+							match result {
+								Err(problem) => Err(problem)
+								Ok(sum) =>
+									if sum > (18446744073709551615 - d) / 10 {
+										Err("Integer is too large for U64")
+									} else {
+										Ok(sum * 10 + d)
+									}
+							}
 						},
 					)
 				},
 			)
+			.flatten()
 
 	## Try a bunch of different parsers.
 	##
@@ -579,6 +588,15 @@ expect {
 	actual = String.parse_str(String.digits, "0123")?
 	actual == 123
 }
+
+## Multiple digit parsing accepts the largest U64.
+expect {
+	actual = String.parse_str(String.digits, "18446744073709551615")?
+	actual == 18446744073709551615
+}
+
+## Multiple digit parsing rejects values larger than U64 without crashing.
+expect String.parse_str(String.digits, "18446744073709551616").is_err()
 
 ## Multiple digit parsing rejects text without a leading digit.
 expect String.parse_str(String.digits, "not a digit").is_err()


### PR DESCRIPTION
Summary:

- detect U64 overflow while accumulating decimal digits
- return a parsing failure instead of crashing
- cover the maximum U64, the first overflowing value, and the HTTP-version fuzz reproducer

This addresses the unrelated fuzz failure discovered by CI on #47.

Validation:

- roc test package/String.roc
- roc test package/HTTP.roc
- python3 scripts/all_tests.py