### PR TITLE
Enable nightly update auto-merge

### DIFF
--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -6,9 +6,10 @@ after the upstream 09:00 UTC build. Late publication can wait until the next day
 `.roc-version` is the compiler pin. `.github/roc-nightly.json` selects this
 repository's validation workflows, including their validation-only release paths.
 Nightly candidates must pass both current-source bundle tests and committed example
-tests against unchanged released dependency URLs. Package-only pull requests use
-the current-source lane; compiler-pin or example changes additionally exercise the
-published-compatibility lane.
+tests against unchanged released dependency URLs. Both lanes run on pull requests
+to provide stable required checks; the current-source result is authoritative for
+package changes, while the published result is additionally authoritative for
+compiler-pin or committed-example changes.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
 The caller workflows pin shared code to `e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4`.

--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -7,13 +7,16 @@ after the upstream 09:00 UTC build. Late publication can wait until the next day
 repository's validation workflows, including their validation-only release paths.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
-The caller workflows pin shared code to `c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2`.
+The caller workflows pin shared code to `e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4`.
 Dependabot proposes reviewed updates to Actions/workflow references.
 
-Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2/docs/integration.md)
+Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4/docs/integration.md)
 for the PR-creation setting, action allowlists, required checks, and first live
-GITHUB_TOKEN run. Keep default token permissions read-only. The updater never
-approves or merges PRs and receives no protection bypass.
+GITHUB_TOKEN run. Keep default token permissions read-only. Successful candidates
+are merged automatically after the controller independently rechecks their signed
+commit, validation evidence, and branch-protection rules. Failed or abnormal
+candidates remain open for investigation. The controller never approves PRs and
+receives no protection bypass.
 
 `automation/roc-nightly` is reserved for the bot's pin-only commits. Put manual
 compatibility changes on a separate branch. Candidate failures require diagnosis;
@@ -24,6 +27,6 @@ The shared repository owns the controller regression suite. Project tests remain
 in this repository and run on the exact candidate commit. Scheduled bot-token
 acceptance must be verified after merge; file changes alone cannot prove it.
 
-Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2/docs/openssf.md)
+Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4/docs/openssf.md)
 to record project-specific evidence. This integration does not establish badge
 compliance or change repository settings.

--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -5,6 +5,10 @@ after the upstream 09:00 UTC build. Late publication can wait until the next day
 
 `.roc-version` is the compiler pin. `.github/roc-nightly.json` selects this
 repository's validation workflows, including their validation-only release paths.
+Nightly candidates must pass both current-source bundle tests and committed example
+tests against unchanged released dependency URLs. Package-only pull requests use
+the current-source lane; compiler-pin or example changes additionally exercise the
+published-compatibility lane.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
 The caller workflows pin shared code to `e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4`.

--- a/.github/roc-nightly.json
+++ b/.github/roc-nightly.json
@@ -1,4 +1,5 @@
 {
+  "auto_merge": true,
   "workflows": [
     "tests.yaml",
     "release.yml",

--- a/.github/roc-nightly.json
+++ b/.github/roc-nightly.json
@@ -2,6 +2,7 @@
   "auto_merge": true,
   "workflows": [
     "tests.yaml",
+    "published-examples.yml",
     "release.yml",
     "fuzz.yml",
     "codeql.yml"

--- a/.github/workflows/nightly-controller-tests.yml
+++ b/.github/workflows/nightly-controller-tests.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   configuration:
-    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2
+    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4

--- a/.github/workflows/published-examples.yml
+++ b/.github/workflows/published-examples.yml
@@ -1,0 +1,44 @@
+name: Published example compatibility
+
+on:
+  pull_request:
+    paths:
+      - ".roc-version"
+      - "examples/**"
+      - "scripts/test_bundle_examples.py"
+      - ".github/workflows/published-examples.yml"
+  workflow_dispatch:
+    inputs:
+      nightly_validation:
+        description: "Validate a nightly candidate without publishing"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  published-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Read Roc version
+        id: roc-version
+        run: python3 scripts/workflow_helpers.py roc-version --github-output "$GITHUB_OUTPUT"
+
+      - name: Install Roc
+        uses: roc-lang/setup-roc@f5a74bf90aa694b43ab4a7cbfdb19273bc6aa697
+        with:
+          version: nightly-new-compiler
+          nightly-tag: ${{ steps.roc-version.outputs.nightly-tag }}
+
+      - name: Test committed examples against released dependencies
+        run: python3 scripts/test_bundle_examples.py --published

--- a/.github/workflows/published-examples.yml
+++ b/.github/workflows/published-examples.yml
@@ -2,11 +2,6 @@ name: Published example compatibility
 
 on:
   pull_request:
-    paths:
-      - ".roc-version"
-      - "examples/**"
-      - "scripts/test_bundle_examples.py"
-      - ".github/workflows/published-examples.yml"
   workflow_dispatch:
     inputs:
       nightly_validation:

--- a/.github/workflows/update-roc-nightly.yml
+++ b/.github/workflows/update-roc-nightly.yml
@@ -15,4 +15,5 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
-    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2
+      statuses: write
+    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4

--- a/scripts/test_bundle_examples.py
+++ b/scripts/test_bundle_examples.py
@@ -125,6 +125,18 @@ def build_and_run_examples(examples: Sequence[Path], build_dir: Path, roc: str) 
         run([str(output)])
 
 
+def committed_examples(source_dir: Path = ROOT / "examples") -> list[Path]:
+    examples = []
+    for example in sorted(source_dir.glob("*.roc")):
+        if example.name in SKIPPED_EXAMPLES:
+            print(f"Skipping {example.name}: {SKIPPED_EXAMPLES[example.name]}.")
+            continue
+        examples.append(example)
+    if not examples:
+        raise SystemExit("No published examples found")
+    return examples
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -137,7 +149,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="Skip compiled example execution",
     )
+    parser.add_argument(
+        "--published",
+        action="store_true",
+        help="Test committed examples against their unchanged released dependency URLs",
+    )
     args = parser.parse_args(argv)
+
+    if args.published and args.bundle_path is not None:
+        parser.error("--published cannot be combined with --bundle-path")
 
     default_tmp = ROOT / ".roc-parser-tmp"
     tmp_parent = Path(os.environ.get("ROC_PARSER_TMPDIR", default_tmp)).resolve()
@@ -146,9 +166,19 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     with tempfile.TemporaryDirectory(prefix="roc-parser-bundle-", dir=tmp_parent) as tmp:
         tmp_dir = Path(tmp)
+        build_dir = tmp_dir / "build"
+
+        if args.published:
+            examples = committed_examples()
+            print("Testing committed examples with released dependencies")
+            run_example_checks(examples, roc)
+            run_example_apps(examples, roc)
+            if not args.skip_build_run:
+                build_and_run_examples(examples, build_dir, roc)
+            return 0
+
         bundle_dir = tmp_dir / "bundle"
         examples_dir = tmp_dir / "rewritten"
-        build_dir = tmp_dir / "build"
 
         bundle_dir.mkdir()
         examples_dir.mkdir()

--- a/scripts/tests/test_test_bundle_examples.py
+++ b/scripts/tests/test_test_bundle_examples.py
@@ -8,6 +8,18 @@ from scripts import test_bundle_examples
 
 
 class TestBundleExamplesScriptTests(unittest.TestCase):
+    def test_committed_examples_keep_published_urls(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp)
+            example = source / "example.roc"
+            published = "https://example.test/releases/1.2.3/package.tar.zst"
+            example.write_text(f'app [main] {{ parser: "{published}" }}\n', encoding="utf-8")
+
+            examples = test_bundle_examples.committed_examples(source)
+
+            self.assertEqual(examples, [example])
+            self.assertIn(published, example.read_text(encoding="utf-8"))
+
     def test_copy_examples_rewrites_url_and_skips_known_example(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- opt into the shared controller's guarded auto-merge policy
- update the pinned roc-automation revision and grant status publication permission
- add a separate published-compatibility workflow that tests committed examples against unchanged release URLs
- retain current-source validation through temporary examples rewritten to a freshly built bundle
- require both lanes for nightly candidates

## Validation

- `python3 ../roc-automation/actions/nightly/nightly_update.py check`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (45 tests)
- `python3 scripts/test_bundle_examples.py --published`
- `git diff --check`

After this merges, manually dispatch **Update Roc nightly** to exercise the full path without waiting for another nightly.