### PR TITLE
Fix pinned roc-automation revision

### DIFF
--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -12,10 +12,10 @@ package changes, while the published result is additionally authoritative for
 compiler-pin or committed-example changes.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
-The caller workflows pin shared code to `e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4`.
+The caller workflows pin shared code to `e1c09714c4d9e93fc03d2d1e4186ca543bc60d50`.
 Dependabot proposes reviewed updates to Actions/workflow references.
 
-Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4/docs/integration.md)
+Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/e1c09714c4d9e93fc03d2d1e4186ca543bc60d50/docs/integration.md)
 for the PR-creation setting, action allowlists, required checks, and first live
 GITHUB_TOKEN run. Keep default token permissions read-only. Successful candidates
 are merged automatically after the controller independently rechecks their signed
@@ -32,6 +32,6 @@ The shared repository owns the controller regression suite. Project tests remain
 in this repository and run on the exact candidate commit. Scheduled bot-token
 acceptance must be verified after merge; file changes alone cannot prove it.
 
-Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4/docs/openssf.md)
+Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/e1c09714c4d9e93fc03d2d1e4186ca543bc60d50/docs/openssf.md)
 to record project-specific evidence. This integration does not establish badge
 compliance or change repository settings.

--- a/.github/workflows/nightly-controller-tests.yml
+++ b/.github/workflows/nightly-controller-tests.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   configuration:
-    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4
+    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@e1c09714c4d9e93fc03d2d1e4186ca543bc60d50

--- a/.github/workflows/update-roc-nightly.yml
+++ b/.github/workflows/update-roc-nightly.yml
@@ -16,4 +16,4 @@ jobs:
       pull-requests: write
       actions: write
       statuses: write
-    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@e1c09717083a1f8c0e380f9bc33ef1e9c46a78c4
+    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@e1c09714c4d9e93fc03d2d1e4186ca543bc60d50


### PR DESCRIPTION
The auto-merge integration used an incorrectly expanded commit SHA, causing the updater to fail during workflow startup before creating jobs. This replaces it with the verified full SHA for roc-automation commit `e1c0971` in both reusable-workflow callers and documentation.

Validation:
- verified the commit through the GitHub API
- `python3 ../roc-automation/actions/nightly/nightly_update.py check`
- `git diff --check`